### PR TITLE
PR: Return more information when parsing fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
         continue-on-error: true
         
       - name: Annotate Checks
-        uses: agyemanjp/ci-checks-action@2.0.3
+        uses: agyemanjp/ci-checks-action@2.0.4
         with:
           ghToken: ${{ secrets.GITHUB_TOKEN }}
           checks: '[

--- a/dist/index.js
+++ b/dist/index.js
@@ -138,6 +138,95 @@ module.exports =
 /************************************************************************/
 /******/ ({
 
+/***/ 87:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(87);
+
+/***/ }),
+
+/***/ 129:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(129);
+
+/***/ }),
+
+/***/ 211:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(211);
+
+/***/ }),
+
+/***/ 357:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(357);
+
+/***/ }),
+
+/***/ 413:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(413);
+
+/***/ }),
+
+/***/ 429:
+/***/ (function(module, __unusedexports, __nested_webpack_require_2016__) {
+
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete installedModules[moduleId];
+/******/ 		}
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(429);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
 /***/ 0:
 /***/ (function(module, __unusedexports, __nested_webpack_require_1583__) {
 
@@ -1002,7 +1091,7 @@ module.exports = function generate__limitItems(it, $keyword, $ruleType) {
 /***/ 87:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(87);
+module.exports = __nested_webpack_require_2016__(87);
 
 /***/ }),
 
@@ -1984,7 +2073,7 @@ module.exports = uniq;
 /***/ 129:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(129);
+module.exports = __nested_webpack_require_2016__(129);
 
 /***/ }),
 
@@ -2543,7 +2632,7 @@ module.exports.fetch = __nested_webpack_require_71181__(454).default
 /***/ 211:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(211);
+module.exports = __nested_webpack_require_2016__(211);
 
 /***/ }),
 
@@ -6021,7 +6110,7 @@ function request (requestOptions) {
 /***/ 357:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(357);
+module.exports = __nested_webpack_require_2016__(357);
 
 /***/ }),
 
@@ -6543,7 +6632,7 @@ function Octokit (plugins, options) {
 /***/ 413:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(413);
+module.exports = __nested_webpack_require_2016__(413);
 
 /***/ }),
 
@@ -10352,7 +10441,7 @@ function octokitRestApiEndpoints (octokit) {
 /***/ 605:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(605);
+module.exports = __nested_webpack_require_2016__(605);
 
 /***/ }),
 
@@ -10381,7 +10470,7 @@ module.exports = Octokit.plugin(CORE_PLUGINS)
 /***/ 614:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(614);
+module.exports = __nested_webpack_require_2016__(614);
 
 /***/ }),
 
@@ -10435,7 +10524,7 @@ module.exports.env = opts => {
 /***/ 622:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(622);
+module.exports = __nested_webpack_require_2016__(622);
 
 /***/ }),
 
@@ -11132,7 +11221,7 @@ module.exports = function generate_const(it, $keyword, $ruleType) {
 /***/ 669:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(669);
+module.exports = __nested_webpack_require_2016__(669);
 
 /***/ }),
 
@@ -11806,7 +11895,7 @@ function defaultOptions (defaults, route, options) {
 /***/ 747:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(747);
+module.exports = __nested_webpack_require_2016__(747);
 
 /***/ }),
 
@@ -11916,7 +12005,7 @@ function request (requestOptions) {
 /***/ 761:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(761);
+module.exports = __nested_webpack_require_2016__(761);
 
 /***/ }),
 
@@ -12826,7 +12915,7 @@ module.exports = module.exports.Deprecation = Deprecation
 /***/ 835:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(835);
+module.exports = __nested_webpack_require_2016__(835);
 
 /***/ }),
 
@@ -18817,6 +18906,59 @@ function authenticationRequestError (state, error, options) {
     })
 }
 
+
+/***/ })
+
+/******/ });
+
+/***/ }),
+
+/***/ 605:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(605);
+
+/***/ }),
+
+/***/ 614:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(614);
+
+/***/ }),
+
+/***/ 622:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(622);
+
+/***/ }),
+
+/***/ 669:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(669);
+
+/***/ }),
+
+/***/ 747:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(747);
+
+/***/ }),
+
+/***/ 761:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(761);
+
+/***/ }),
+
+/***/ 835:
+/***/ (function(module) {
+
+module.exports = __webpack_require__(835);
 
 /***/ })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -49,101 +49,12 @@ module.exports =
 /************************************************************************/
 /******/ ({
 
-/***/ 87:
-/***/ (function(module) {
-
-module.exports = require("os");
-
-/***/ }),
-
-/***/ 129:
-/***/ (function(module) {
-
-module.exports = require("child_process");
-
-/***/ }),
-
-/***/ 211:
-/***/ (function(module) {
-
-module.exports = require("https");
-
-/***/ }),
-
-/***/ 357:
-/***/ (function(module) {
-
-module.exports = require("assert");
-
-/***/ }),
-
-/***/ 413:
-/***/ (function(module) {
-
-module.exports = require("stream");
-
-/***/ }),
-
-/***/ 429:
-/***/ (function(module, __unusedexports, __webpack_require__) {
-
-module.exports =
-/******/ (function(modules, runtime) { // webpackBootstrap
-/******/ 	"use strict";
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
-/******/
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId]) {
-/******/ 			return installedModules[moduleId].exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			i: moduleId,
-/******/ 			l: false,
-/******/ 			exports: {}
-/******/ 		};
-/******/
-/******/ 		// Execute the module function
-/******/ 		var threw = true;
-/******/ 		try {
-/******/ 			modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/ 			threw = false;
-/******/ 		} finally {
-/******/ 			if(threw) delete installedModules[moduleId];
-/******/ 		}
-/******/
-/******/ 		// Flag the module as loaded
-/******/ 		module.l = true;
-/******/
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/
-/******/
-/******/ 	__webpack_require__.ab = __dirname + "/";
-/******/
-/******/ 	// the startup function
-/******/ 	function startup() {
-/******/ 		// Load entry module and return exports
-/******/ 		return __webpack_require__(429);
-/******/ 	};
-/******/
-/******/ 	// run startup
-/******/ 	return startup();
-/******/ })
-/************************************************************************/
-/******/ ({
-
 /***/ 0:
-/***/ (function(module, __unusedexports, __nested_webpack_require_1583__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = withDefaults
 
-const graphql = __nested_webpack_require_1583__(500)
+const graphql = __webpack_require__(500)
 
 function withDefaults (request, newDefaults) {
   const newRequest = request.defaults(newDefaults)
@@ -159,13 +70,13 @@ function withDefaults (request, newDefaults) {
 /***/ }),
 
 /***/ 2:
-/***/ (function(module, __unusedexports, __nested_webpack_require_2012__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
-const os = __nested_webpack_require_2012__(87);
-const macosRelease = __nested_webpack_require_2012__(964);
-const winRelease = __nested_webpack_require_2012__(49);
+const os = __webpack_require__(87);
+const macosRelease = __webpack_require__(964);
+const winRelease = __webpack_require__(49);
 
 const osName = (platform, release) => {
 	if (!platform && release) {
@@ -247,9 +158,9 @@ function iterator (octokit, options) {
 /***/ }),
 
 /***/ 9:
-/***/ (function(module, __unusedexports, __nested_webpack_require_4093__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-var once = __nested_webpack_require_4093__(969);
+var once = __webpack_require__(969);
 
 var noop = function() {};
 
@@ -396,13 +307,13 @@ module.exports = eval("require")("encoding");
 /***/ }),
 
 /***/ 19:
-/***/ (function(module, __unusedexports, __nested_webpack_require_7919__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = authenticationPlugin
 
-const authenticate = __nested_webpack_require_7919__(674)
-const beforeRequest = __nested_webpack_require_7919__(471)
-const requestError = __nested_webpack_require_7919__(349)
+const authenticate = __webpack_require__(674)
+const beforeRequest = __webpack_require__(471)
+const requestError = __webpack_require__(349)
 
 function authenticationPlugin (octokit, options) {
   if (options.auth) {
@@ -424,14 +335,14 @@ function authenticationPlugin (octokit, options) {
 /***/ }),
 
 /***/ 20:
-/***/ (function(module, __unusedexports, __nested_webpack_require_8695__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-const cp = __nested_webpack_require_8695__(129);
-const parse = __nested_webpack_require_8695__(568);
-const enoent = __nested_webpack_require_8695__(881);
+const cp = __webpack_require__(129);
+const parse = __webpack_require__(568);
+const enoent = __webpack_require__(881);
 
 function spawn(command, args, options) {
     // Parse the arguments
@@ -493,11 +404,11 @@ module.exports = function generate_comment(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 30:
-/***/ (function(module, __unusedexports, __nested_webpack_require_10603__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = getLastPage
 
-const getPage = __nested_webpack_require_10603__(265)
+const getPage = __webpack_require__(265)
 
 function getLastPage (octokit, link, headers) {
   return getPage(octokit, link, 'last', headers)
@@ -654,19 +565,19 @@ module.exports = opts => {
 /***/ 41:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/request@2.3.0","/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks"]],"_from":"@octokit/request@2.3.0","_id":"@octokit/request@2.3.0","_inBundle":false,"_integrity":"sha512-5YRqYNZOAaL7+nt7w3Scp6Sz4P2g7wKFP9npx1xdExMomk8/M/ICXVLYVam2wzxeY0cIc6wcKpjC5KI4jiNbGw==","_location":"/@octokit/rest/@octokit/request","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/request@2.3.0","name":"@octokit/request","escapedName":"@octokit%2frequest","scope":"@octokit","rawSpec":"2.3.0","saveSpec":null,"fetchSpec":"2.3.0"},"_requiredBy":["/@octokit/rest"],"_resolved":"https://registry.npmjs.org/@octokit/request/-/request-2.3.0.tgz","_spec":"2.3.0","_where":"/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"browser":{"./lib/get-request-agent.js":false,"./lib/request/get-buffer-response.js":"./lib/request/get-buffer-response-browser.js"},"bugs":{"url":"https://github.com/octokit/request.js/issues"},"bundlesize":[{"path":"./dist/octokit-request.min.js.gz","maxSize":"5KB"}],"dependencies":{"@octokit/endpoint":"^3.1.1","is-plain-object":"^2.0.4","node-fetch":"^2.3.0","universal-user-agent":"^2.0.1"},"description":"Send parameterized requests to GitHub’s APIs with sensible defaults in browsers and Node","devDependencies":{"chai":"^4.2.0","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.2","cypress":"^3.1.0","fetch-mock":"^7.2.0","mkdirp":"^0.5.1","mocha":"^5.2.0","npm-run-all":"^4.1.3","nyc":"^13.1.0","semantic-release":"^15.10.5","simple-mock":"^0.8.0","standard":"^12.0.1","webpack":"^4.22.0","webpack-bundle-analyzer":"^3.0.3","webpack-cli":"^3.1.2"},"files":["lib"],"homepage":"https://github.com/octokit/request.js#readme","keywords":["octokit","github","api","request"],"license":"MIT","main":"index.js","name":"@octokit/request","publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/request.js.git"},"scripts":{"build":"npm-run-all build:*","build:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-request.js --profile --json > dist/bundle-stats.json","build:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-request.min.js --devtool source-map","bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","prebuild":"mkdirp dist/","pretest":"standard","semantic-release":"semantic-release","test":"nyc mocha test/*-test.js","test:browser":"cypress run --browser chrome"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect"]},"version":"2.3.0"};
+module.exports = {"_args":[["@octokit/request@2.3.0","/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action"]],"_from":"@octokit/request@2.3.0","_id":"@octokit/request@2.3.0","_inBundle":false,"_integrity":"sha512-5YRqYNZOAaL7+nt7w3Scp6Sz4P2g7wKFP9npx1xdExMomk8/M/ICXVLYVam2wzxeY0cIc6wcKpjC5KI4jiNbGw==","_location":"/@octokit/rest/@octokit/request","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/request@2.3.0","name":"@octokit/request","escapedName":"@octokit%2frequest","scope":"@octokit","rawSpec":"2.3.0","saveSpec":null,"fetchSpec":"2.3.0"},"_requiredBy":["/@octokit/rest"],"_resolved":"https://registry.npmjs.org/@octokit/request/-/request-2.3.0.tgz","_spec":"2.3.0","_where":"/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"browser":{"./lib/get-request-agent.js":false,"./lib/request/get-buffer-response.js":"./lib/request/get-buffer-response-browser.js"},"bugs":{"url":"https://github.com/octokit/request.js/issues"},"bundlesize":[{"path":"./dist/octokit-request.min.js.gz","maxSize":"5KB"}],"dependencies":{"@octokit/endpoint":"^3.1.1","is-plain-object":"^2.0.4","node-fetch":"^2.3.0","universal-user-agent":"^2.0.1"},"description":"Send parameterized requests to GitHub’s APIs with sensible defaults in browsers and Node","devDependencies":{"chai":"^4.2.0","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.2","cypress":"^3.1.0","fetch-mock":"^7.2.0","mkdirp":"^0.5.1","mocha":"^5.2.0","npm-run-all":"^4.1.3","nyc":"^13.1.0","semantic-release":"^15.10.5","simple-mock":"^0.8.0","standard":"^12.0.1","webpack":"^4.22.0","webpack-bundle-analyzer":"^3.0.3","webpack-cli":"^3.1.2"},"files":["lib"],"homepage":"https://github.com/octokit/request.js#readme","keywords":["octokit","github","api","request"],"license":"MIT","main":"index.js","name":"@octokit/request","publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/request.js.git"},"scripts":{"build":"npm-run-all build:*","build:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-request.js --profile --json > dist/bundle-stats.json","build:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-request.min.js --devtool source-map","bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","prebuild":"mkdirp dist/","pretest":"standard","semantic-release":"semantic-release","test":"nyc mocha test/*-test.js","test:browser":"cypress run --browser chrome"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect"]},"version":"2.3.0"};
 
 /***/ }),
 
 /***/ 45:
-/***/ (function(module, __unusedexports, __nested_webpack_require_18340__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
 var IDENTIFIER = /^[a-z_$][a-z0-9_$-]*$/i;
-var customRuleCode = __nested_webpack_require_18340__(187);
-var definitionSchema = __nested_webpack_require_18340__(952);
+var customRuleCode = __webpack_require__(187);
+var definitionSchema = __webpack_require__(952);
 
 module.exports = {
   add: addKeyword,
@@ -813,11 +724,11 @@ function validateKeyword(definition, throwError) {
 /***/ }),
 
 /***/ 46:
-/***/ (function(module, __unusedexports, __nested_webpack_require_22333__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = getUserAgentNode
 
-const osName = __nested_webpack_require_22333__(2)
+const osName = __webpack_require__(2)
 
 function getUserAgentNode () {
   try {
@@ -835,12 +746,12 @@ function getUserAgentNode () {
 /***/ }),
 
 /***/ 47:
-/***/ (function(module, __unusedexports, __nested_webpack_require_22763__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = factory
 
-const Octokit = __nested_webpack_require_22763__(402)
-const registerPlugin = __nested_webpack_require_22763__(855)
+const Octokit = __webpack_require__(402)
+const registerPlugin = __webpack_require__(855)
 
 function factory (plugins) {
   const Api = Octokit.bind(null, plugins || [])
@@ -852,12 +763,12 @@ function factory (plugins) {
 /***/ }),
 
 /***/ 49:
-/***/ (function(module, __unusedexports, __nested_webpack_require_23115__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
-const os = __nested_webpack_require_23115__(87);
-const execa = __nested_webpack_require_23115__(955);
+const os = __webpack_require__(87);
+const execa = __webpack_require__(955);
 
 // Reference: https://www.gaijin.at/en/lstwinver.php
 const names = new Map([
@@ -1002,7 +913,7 @@ module.exports = function generate__limitItems(it, $keyword, $ruleType) {
 /***/ 87:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(87);
+module.exports = require("os");
 
 /***/ }),
 
@@ -1057,13 +968,13 @@ module.exports = function generate_allOf(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 118:
-/***/ (function(module, __unusedexports, __nested_webpack_require_29041__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = withDefaults
 
-const endpointWithDefaults = __nested_webpack_require_29041__(284)
-const merge = __nested_webpack_require_29041__(742)
-const parse = __nested_webpack_require_29041__(474)
+const endpointWithDefaults = __webpack_require__(284)
+const merge = __webpack_require__(742)
+const parse = __webpack_require__(474)
 
 function withDefaults (oldDefaults, newDefaults) {
   const DEFAULTS = merge(oldDefaults, newDefaults)
@@ -1984,17 +1895,17 @@ module.exports = uniq;
 /***/ 129:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(129);
+module.exports = require("child_process");
 
 /***/ }),
 
 /***/ 145:
-/***/ (function(module, __unusedexports, __nested_webpack_require_51612__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
-const pump = __nested_webpack_require_51612__(453);
-const bufferStream = __nested_webpack_require_51612__(966);
+const pump = __webpack_require__(453);
+const bufferStream = __webpack_require__(966);
 
 class MaxBufferError extends Error {
 	constructor() {
@@ -2054,12 +1965,12 @@ module.exports = {"$schema":"http://json-schema.org/draft-07/schema#","type":"ob
 /***/ }),
 
 /***/ 148:
-/***/ (function(module, __unusedexports, __nested_webpack_require_54913__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = paginatePlugin
 
-const iterator = __nested_webpack_require_54913__(8)
-const paginate = __nested_webpack_require_54913__(807)
+const iterator = __webpack_require__(8)
+const paginate = __webpack_require__(807)
 
 function paginatePlugin (octokit) {
   octokit.paginate = paginate.bind(null, octokit)
@@ -2456,13 +2367,13 @@ module.exports = function generate_custom(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 190:
-/***/ (function(module, __unusedexports, __nested_webpack_require_69585__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = authenticationPlugin
 
-const beforeRequest = __nested_webpack_require_69585__(863)
-const requestError = __nested_webpack_require_69585__(991)
-const validate = __nested_webpack_require_69585__(954)
+const beforeRequest = __webpack_require__(863)
+const requestError = __webpack_require__(991)
+const validate = __webpack_require__(954)
 
 function authenticationPlugin (octokit, options) {
   if (!options.auth) {
@@ -2484,12 +2395,12 @@ function authenticationPlugin (octokit, options) {
 /***/ }),
 
 /***/ 197:
-/***/ (function(module, __unusedexports, __nested_webpack_require_70156__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = isexe
 isexe.sync = sync
 
-var fs = __nested_webpack_require_70156__(747)
+var fs = __webpack_require__(747)
 
 function isexe (path, options, cb) {
   fs.stat(path, function (er, stat) {
@@ -2532,10 +2443,10 @@ function checkMode (stat, options) {
 /***/ }),
 
 /***/ 209:
-/***/ (function(module, __unusedexports, __nested_webpack_require_71165__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 // expose internally used `fetch` method for testing/mocking only
-module.exports.fetch = __nested_webpack_require_71165__(454).default
+module.exports.fetch = __webpack_require__(454).default
 
 
 /***/ }),
@@ -2543,14 +2454,14 @@ module.exports.fetch = __nested_webpack_require_71165__(454).default
 /***/ 211:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(211);
+module.exports = require("https");
 
 /***/ }),
 
 /***/ 215:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/rest@16.15.0","/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks"]],"_from":"@octokit/rest@16.15.0","_id":"@octokit/rest@16.15.0","_inBundle":false,"_integrity":"sha512-Un+e7rgh38RtPOTe453pT/KPM/p2KZICimBmuZCd2wEo8PacDa4h6RqTPZs+f2DPazTTqdM7QU4LKlUjgiBwWw==","_location":"/@octokit/rest","_phantomChildren":{"@octokit/endpoint":"3.2.3","is-plain-object":"2.0.4","node-fetch":"2.6.0","universal-user-agent":"2.1.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.15.0","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.15.0","saveSpec":null,"fetchSpec":"16.15.0"},"_requiredBy":["/","/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.15.0.tgz","_spec":"16.15.0","_where":"/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks","apidoc":{"template":{"withCompare":false}},"author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/request":"2.3.0","before-after-hook":"^1.2.0","btoa-lite":"^1.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","universal-user-agent":"^2.0.0","url-template":"^2.0.8"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/fixtures-server":"^5.0.1","@octokit/routes":"18.4.0","@types/node":"^10.1.2","apidoc":"^0.17.6","bundlesize":"^0.17.0","chai":"^4.1.2","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.0","dotenv":"^6.0.0","gh-pages-with-token":"^1.0.0","glob":"^7.1.2","http-proxy-agent":"^2.1.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","mkdirp":"^0.5.1","mocha":"^5.0.0","mustache":"^3.0.0","nock":"^10.0.0","npm-run-all":"^4.1.2","nyc":"^12.0.1","prettier":"^1.14.2","proxy":"^0.2.4","semantic-release":"^15.0.0","sinon":"^6.0.0","sinon-chai":"^3.0.0","sort-keys":"^2.0.0","standard":"^12.0.0","string-to-arraybuffer":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:docs":"node scripts/generate-api-docs","build:ts":"node scripts/generate-types","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","deploy-docs":"gh-pages-with-token -d doc","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","generate-routes":"node scripts/generate-routes","postbuild:docs":"apidoc -i doc/ -o doc/","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","prebuild:docs":"mkdirp doc/","pretest":"standard","prevalidate:ts":"npm run -s build:ts","semantic-release":"semantic-release","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","test:memory":"mocha test/memory-test","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect","cy"]},"types":"index.d.ts","version":"16.15.0"};
+module.exports = {"_args":[["@octokit/rest@16.15.0","/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action"]],"_from":"@octokit/rest@16.15.0","_id":"@octokit/rest@16.15.0","_inBundle":false,"_integrity":"sha512-Un+e7rgh38RtPOTe453pT/KPM/p2KZICimBmuZCd2wEo8PacDa4h6RqTPZs+f2DPazTTqdM7QU4LKlUjgiBwWw==","_location":"/@octokit/rest","_phantomChildren":{"@octokit/endpoint":"3.2.3","is-plain-object":"2.0.4","node-fetch":"2.6.0","universal-user-agent":"2.1.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.15.0","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.15.0","saveSpec":null,"fetchSpec":"16.15.0"},"_requiredBy":["/","/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.15.0.tgz","_spec":"16.15.0","_where":"/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action","apidoc":{"template":{"withCompare":false}},"author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/request":"2.3.0","before-after-hook":"^1.2.0","btoa-lite":"^1.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","universal-user-agent":"^2.0.0","url-template":"^2.0.8"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/fixtures-server":"^5.0.1","@octokit/routes":"18.4.0","@types/node":"^10.1.2","apidoc":"^0.17.6","bundlesize":"^0.17.0","chai":"^4.1.2","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.0","dotenv":"^6.0.0","gh-pages-with-token":"^1.0.0","glob":"^7.1.2","http-proxy-agent":"^2.1.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","mkdirp":"^0.5.1","mocha":"^5.0.0","mustache":"^3.0.0","nock":"^10.0.0","npm-run-all":"^4.1.2","nyc":"^12.0.1","prettier":"^1.14.2","proxy":"^0.2.4","semantic-release":"^15.0.0","sinon":"^6.0.0","sinon-chai":"^3.0.0","sort-keys":"^2.0.0","standard":"^12.0.0","string-to-arraybuffer":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:docs":"node scripts/generate-api-docs","build:ts":"node scripts/generate-types","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","deploy-docs":"gh-pages-with-token -d doc","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","generate-routes":"node scripts/generate-routes","postbuild:docs":"apidoc -i doc/ -o doc/","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","prebuild:docs":"mkdirp doc/","pretest":"standard","prevalidate:ts":"npm run -s build:ts","semantic-release":"semantic-release","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","test:memory":"mocha test/memory-test","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect","cy"]},"types":"index.d.ts","version":"16.15.0"};
 
 /***/ }),
 
@@ -2731,11 +2642,11 @@ module.exports = function generate_dependencies(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 242:
-/***/ (function(module, __unusedexports, __nested_webpack_require_83789__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = withDefaults
 
-const request = __nested_webpack_require_83789__(755)
+const request = __webpack_require__(755)
 
 function withDefaults (oldEndpoint, newDefaults) {
   const endpoint = oldEndpoint.defaults(newDefaults)
@@ -2752,11 +2663,11 @@ function withDefaults (oldEndpoint, newDefaults) {
 /***/ }),
 
 /***/ 248:
-/***/ (function(module, __unusedexports, __nested_webpack_require_84251__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = octokitRegisterEndpoints
 
-const registerEndpoints = __nested_webpack_require_84251__(899)
+const registerEndpoints = __webpack_require__(899)
 
 function octokitRegisterEndpoints (octokit) {
   octokit.registerEndpoints = registerEndpoints.bind(null, octokit)
@@ -2766,16 +2677,16 @@ function octokitRegisterEndpoints (octokit) {
 /***/ }),
 
 /***/ 260:
-/***/ (function(module, __unusedexports, __nested_webpack_require_84551__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 // Note: since nyc uses this module to output coverage, any lines
 // that are in the direct sync flow of nyc's outputCoverage are
 // ignored, since we can never get coverage for them.
-var assert = __nested_webpack_require_84551__(357)
-var signals = __nested_webpack_require_84551__(654)
+var assert = __webpack_require__(357)
+var signals = __webpack_require__(654)
 var isWin = /^win/i.test(process.platform)
 
-var EE = __nested_webpack_require_84551__(614)
+var EE = __webpack_require__(614)
 /* istanbul ignore if */
 if (typeof EE !== 'function') {
   EE = EE.EventEmitter
@@ -2965,13 +2876,13 @@ module.exports = class HttpError extends Error {
 /***/ }),
 
 /***/ 262:
-/***/ (function(__unusedmodule, exports, __nested_webpack_require_89428__) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const fs_1 = __nested_webpack_require_89428__(747);
-const os_1 = __nested_webpack_require_89428__(87);
+const fs_1 = __webpack_require__(747);
+const os_1 = __webpack_require__(87);
 class Context {
     /**
      * Hydrate the context from the environment
@@ -3017,13 +2928,13 @@ exports.Context = Context;
 /***/ }),
 
 /***/ 265:
-/***/ (function(module, __unusedexports, __nested_webpack_require_91248__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = getPage
 
-const deprecate = __nested_webpack_require_91248__(370)
-const getPageLinks = __nested_webpack_require_91248__(577)
-const HttpError = __nested_webpack_require_91248__(297)
+const deprecate = __webpack_require__(370)
+const getPageLinks = __webpack_require__(577)
+const HttpError = __webpack_require__(297)
 
 function getPage (octokit, link, which, headers) {
   deprecate(`octokit.get${which.charAt(0).toUpperCase() + which.slice(1)}Page() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -3194,10 +3105,10 @@ module.exports = function generate_ref(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 277:
-/***/ (function(module, __unusedexports, __nested_webpack_require_97161__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-const Deprecation = __nested_webpack_require_97161__(832)
-const logOnce = __nested_webpack_require_97161__(969)(deprecation => console.warn(deprecation))
+const Deprecation = __webpack_require__(832)
+const logOnce = __webpack_require__(969)(deprecation => console.warn(deprecation))
 
 module.exports = class HttpError extends Error {
   constructor (message, statusCode, headers, request) {
@@ -4914,12 +4825,12 @@ module.exports = function generate_enum(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 284:
-/***/ (function(module, __unusedexports, __nested_webpack_require_143180__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = endpointWithDefaults
 
-const merge = __nested_webpack_require_143180__(742)
-const parse = __nested_webpack_require_143180__(474)
+const merge = __webpack_require__(742)
+const parse = __webpack_require__(474)
 
 function endpointWithDefaults (defaults, route, options) {
   return parse(merge(defaults, route, options))
@@ -4958,13 +4869,13 @@ function addQueryParameters (url, parameters) {
 /***/ }),
 
 /***/ 294:
-/***/ (function(module, __unusedexports, __nested_webpack_require_144044__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = parseOptions
 
-const getUserAgent = __nested_webpack_require_144044__(46)
+const getUserAgent = __webpack_require__(46)
 
-const pkg = __nested_webpack_require_144044__(215)
+const pkg = __webpack_require__(215)
 
 function parseOptions (options, log) {
   if (options.headers) {
@@ -5056,11 +4967,11 @@ function omit (object, keysToOmit) {
 /***/ }),
 
 /***/ 307:
-/***/ (function(module, __unusedexports, __nested_webpack_require_146512__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-const getUserAgent = __nested_webpack_require_146512__(46)
+const getUserAgent = __webpack_require__(46)
 
-const version = __nested_webpack_require_146512__(724).version
+const version = __webpack_require__(724).version
 const userAgent = `octokit-endpoint.js/${version} ${getUserAgent()}`
 
 module.exports = {
@@ -5082,7 +4993,7 @@ module.exports = {
 /***/ 314:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/graphql@2.0.1","/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks"]],"_from":"@octokit/graphql@2.0.1","_id":"@octokit/graphql@2.0.1","_inBundle":false,"_integrity":"sha512-IBNr05yBYqffy9L37Vv3/5xQMw+swmYFtMsuwqUA5vSEUr+s/POf8DOpCaTtS8f7e9k+cEuKLC5AbOoXkdZZOA==","_location":"/@octokit/graphql","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/graphql@2.0.1","name":"@octokit/graphql","escapedName":"@octokit%2fgraphql","scope":"@octokit","rawSpec":"2.0.1","saveSpec":null,"fetchSpec":"2.0.1"},"_requiredBy":["/","/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/graphql/-/graphql-2.0.1.tgz","_spec":"2.0.1","_where":"/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/graphql.js/issues"},"bundlesize":[{"path":"./dist/octokit-graphql.min.js.gz","maxSize":"5KB"}],"dependencies":{"@octokit/request":"^2.1.2"},"description":"GitHub GraphQL API client for browsers and Node","devDependencies":{"chai":"^4.2.0","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.2","cypress":"^3.1.0","fetch-mock":"^7.2.0","mkdirp":"^0.5.1","mocha":"^5.2.0","npm-run-all":"^4.1.3","nyc":"^13.1.0","semantic-release":"^15.12.1","simple-mock":"^0.8.0","standard":"^12.0.1","webpack":"^4.22.0","webpack-bundle-analyzer":"^3.0.3","webpack-cli":"^3.1.2"},"files":["lib"],"homepage":"https://github.com/octokit/graphql.js#readme","keywords":["octokit","github","api","graphql"],"license":"MIT","main":"index.js","name":"@octokit/graphql","publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/graphql.js.git"},"scripts":{"build":"npm-run-all build:*","build:development":"webpack --mode development --entry . --output-library=octokitGraphql --output=./dist/octokit-graphql.js --profile --json > dist/bundle-stats.json","build:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=octokitGraphql --output-path=./dist --output-filename=octokit-graphql.min.js --devtool source-map","bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","prebuild":"mkdirp dist/","pretest":"standard","test":"nyc mocha test/*-test.js","test:browser":"cypress run --browser chrome"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect"]},"version":"2.0.1"};
+module.exports = {"_args":[["@octokit/graphql@2.0.1","/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action"]],"_from":"@octokit/graphql@2.0.1","_id":"@octokit/graphql@2.0.1","_inBundle":false,"_integrity":"sha512-IBNr05yBYqffy9L37Vv3/5xQMw+swmYFtMsuwqUA5vSEUr+s/POf8DOpCaTtS8f7e9k+cEuKLC5AbOoXkdZZOA==","_location":"/@octokit/graphql","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/graphql@2.0.1","name":"@octokit/graphql","escapedName":"@octokit%2fgraphql","scope":"@octokit","rawSpec":"2.0.1","saveSpec":null,"fetchSpec":"2.0.1"},"_requiredBy":["/","/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/graphql/-/graphql-2.0.1.tgz","_spec":"2.0.1","_where":"/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/graphql.js/issues"},"bundlesize":[{"path":"./dist/octokit-graphql.min.js.gz","maxSize":"5KB"}],"dependencies":{"@octokit/request":"^2.1.2"},"description":"GitHub GraphQL API client for browsers and Node","devDependencies":{"chai":"^4.2.0","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.2","cypress":"^3.1.0","fetch-mock":"^7.2.0","mkdirp":"^0.5.1","mocha":"^5.2.0","npm-run-all":"^4.1.3","nyc":"^13.1.0","semantic-release":"^15.12.1","simple-mock":"^0.8.0","standard":"^12.0.1","webpack":"^4.22.0","webpack-bundle-analyzer":"^3.0.3","webpack-cli":"^3.1.2"},"files":["lib"],"homepage":"https://github.com/octokit/graphql.js#readme","keywords":["octokit","github","api","graphql"],"license":"MIT","main":"index.js","name":"@octokit/graphql","publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/graphql.js.git"},"scripts":{"build":"npm-run-all build:*","build:development":"webpack --mode development --entry . --output-library=octokitGraphql --output=./dist/octokit-graphql.js --profile --json > dist/bundle-stats.json","build:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=octokitGraphql --output-path=./dist --output-filename=octokit-graphql.min.js --devtool source-map","bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","prebuild":"mkdirp dist/","pretest":"standard","test":"nyc mocha test/*-test.js","test:browser":"cypress run --browser chrome"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect"]},"version":"2.0.1"};
 
 /***/ }),
 
@@ -5116,11 +5027,11 @@ isStream.transform = function (stream) {
 /***/ }),
 
 /***/ 326:
-/***/ (function(module, __unusedexports, __nested_webpack_require_150686__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = withDefaults
 
-const request = __nested_webpack_require_150686__(354)
+const request = __webpack_require__(354)
 
 function withDefaults (oldEndpoint, newDefaults) {
   const endpoint = oldEndpoint.defaults(newDefaults)
@@ -5137,12 +5048,12 @@ function withDefaults (oldEndpoint, newDefaults) {
 /***/ }),
 
 /***/ 336:
-/***/ (function(module, __unusedexports, __nested_webpack_require_151148__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = hasLastPage
 
-const deprecate = __nested_webpack_require_151148__(370)
-const getPageLinks = __nested_webpack_require_151148__(577)
+const deprecate = __webpack_require__(370)
+const getPageLinks = __webpack_require__(577)
 
 function hasLastPage (link) {
   deprecate(`octokit.hasLastPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -5771,16 +5682,16 @@ module.exports = function generate_properties(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 348:
-/***/ (function(module, __unusedexports, __nested_webpack_require_177038__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
 module.exports = validate
 
-const set = __nested_webpack_require_177038__(883)
-const get = __nested_webpack_require_177038__(854)
-const HttpError = __nested_webpack_require_177038__(261)
+const set = __webpack_require__(883)
+const get = __webpack_require__(854)
+const HttpError = __webpack_require__(261)
 
 function validate (options) {
   if (!options.request.validate) {
@@ -5880,11 +5791,11 @@ function validate (options) {
 /***/ }),
 
 /***/ 349:
-/***/ (function(module, __unusedexports, __nested_webpack_require_180475__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = authenticationRequestError
 
-const HttpError = __nested_webpack_require_180475__(261)
+const HttpError = __webpack_require__(261)
 
 function authenticationRequestError (state, error, options) {
   const otpRequired = /required/.test(error.headers['x-github-otp'] || '')
@@ -5917,15 +5828,15 @@ function authenticationRequestError (state, error, options) {
 /***/ }),
 
 /***/ 354:
-/***/ (function(module, __unusedexports, __nested_webpack_require_181646__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = request
 
-const isPlainObject = __nested_webpack_require_181646__(960)
+const isPlainObject = __webpack_require__(960)
 
-const mockable = __nested_webpack_require_181646__(209)
-const getBuffer = __nested_webpack_require_181646__(972)
-const HttpError = __nested_webpack_require_181646__(261)
+const mockable = __webpack_require__(209)
+const getBuffer = __webpack_require__(972)
+const HttpError = __webpack_require__(261)
 
 function request (requestOptions) {
   if (isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
@@ -6021,7 +5932,7 @@ function request (requestOptions) {
 /***/ 357:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(357);
+module.exports = require("assert");
 
 /***/ }),
 
@@ -6114,48 +6025,48 @@ function octokitDebug (octokit) {
 /***/ }),
 
 /***/ 383:
-/***/ (function(module, __unusedexports, __nested_webpack_require_186040__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
 //all requires must be explicit because browserify won't work with dynamic requires
 module.exports = {
-  '$ref': __nested_webpack_require_186040__(266),
-  allOf: __nested_webpack_require_186040__(107),
-  anyOf: __nested_webpack_require_186040__(902),
-  '$comment': __nested_webpack_require_186040__(28),
-  const: __nested_webpack_require_186040__(662),
-  contains: __nested_webpack_require_186040__(154),
-  dependencies: __nested_webpack_require_186040__(233),
-  'enum': __nested_webpack_require_186040__(281),
-  format: __nested_webpack_require_186040__(687),
-  'if': __nested_webpack_require_186040__(658),
-  items: __nested_webpack_require_186040__(643),
-  maximum: __nested_webpack_require_186040__(341),
-  minimum: __nested_webpack_require_186040__(341),
-  maxItems: __nested_webpack_require_186040__(85),
-  minItems: __nested_webpack_require_186040__(85),
-  maxLength: __nested_webpack_require_186040__(772),
-  minLength: __nested_webpack_require_186040__(772),
-  maxProperties: __nested_webpack_require_186040__(560),
-  minProperties: __nested_webpack_require_186040__(560),
-  multipleOf: __nested_webpack_require_186040__(397),
-  not: __nested_webpack_require_186040__(673),
-  oneOf: __nested_webpack_require_186040__(653),
-  pattern: __nested_webpack_require_186040__(542),
-  properties: __nested_webpack_require_186040__(343),
-  propertyNames: __nested_webpack_require_186040__(566),
-  required: __nested_webpack_require_186040__(858),
-  uniqueItems: __nested_webpack_require_186040__(434),
-  validate: __nested_webpack_require_186040__(967)
+  '$ref': __webpack_require__(266),
+  allOf: __webpack_require__(107),
+  anyOf: __webpack_require__(902),
+  '$comment': __webpack_require__(28),
+  const: __webpack_require__(662),
+  contains: __webpack_require__(154),
+  dependencies: __webpack_require__(233),
+  'enum': __webpack_require__(281),
+  format: __webpack_require__(687),
+  'if': __webpack_require__(658),
+  items: __webpack_require__(643),
+  maximum: __webpack_require__(341),
+  minimum: __webpack_require__(341),
+  maxItems: __webpack_require__(85),
+  minItems: __webpack_require__(85),
+  maxLength: __webpack_require__(772),
+  minLength: __webpack_require__(772),
+  maxProperties: __webpack_require__(560),
+  minProperties: __webpack_require__(560),
+  multipleOf: __webpack_require__(397),
+  not: __webpack_require__(673),
+  oneOf: __webpack_require__(653),
+  pattern: __webpack_require__(542),
+  properties: __webpack_require__(343),
+  propertyNames: __webpack_require__(566),
+  required: __webpack_require__(858),
+  uniqueItems: __webpack_require__(434),
+  validate: __webpack_require__(967)
 };
 
 
 /***/ }),
 
 /***/ 387:
-/***/ (function(__unusedmodule, exports, __nested_webpack_require_187308__) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
@@ -6184,14 +6095,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const fs = __importStar(__nested_webpack_require_187308__(747));
-const path = __importStar(__nested_webpack_require_187308__(622));
-const core = __importStar(__nested_webpack_require_187308__(470));
-const github = __importStar(__nested_webpack_require_187308__(469));
-const ajv_1 = __importDefault(__nested_webpack_require_187308__(514));
+const fs = __importStar(__webpack_require__(747));
+const path = __importStar(__webpack_require__(622));
+const core = __importStar(__webpack_require__(470));
+const github = __importStar(__webpack_require__(469));
+const ajv_1 = __importDefault(__webpack_require__(514));
 // import colors from 'colors/safe'
-const utility_1 = __nested_webpack_require_187308__(31);
-const generalCheckSchema = __importStar(__nested_webpack_require_187308__(146));
+const utility_1 = __webpack_require__(31);
+const generalCheckSchema = __importStar(__webpack_require__(146));
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function getChecksToReport() {
     const checks = JSON.parse(core.getInput('checks', { required: true }));
@@ -6204,7 +6115,19 @@ function parse(generalCheckJSON, changedFiles, checkName) {
     // console.log(`Parsing check JSON: "${generalCheckJSON}"`)
     // console.log(`changed files: ${changedFiles}`)
     var _a;
-    const toValidate = JSON.parse(generalCheckJSON);
+    let toValidate;
+    try {
+        toValidate = JSON.parse(generalCheckJSON);
+    }
+    catch (err) {
+        return {
+            title: "Could not parse the output file",
+            summary: err,
+            conclusion: 'failure',
+            text: generalCheckJSON,
+            annotations: []
+        };
+    }
     const valid = new ajv_1.default().validate(generalCheckSchema, toValidate);
     if (valid === false) {
         throw new Error(`Error parsing check script output`);
@@ -6367,13 +6290,13 @@ exports.run = run;
 /***/ }),
 
 /***/ 389:
-/***/ (function(module, __unusedexports, __nested_webpack_require_198963__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-const fs = __nested_webpack_require_198963__(747);
-const shebangCommand = __nested_webpack_require_198963__(866);
+const fs = __webpack_require__(747);
+const shebangCommand = __webpack_require__(866);
 
 function readShebang(command) {
     // Read the first 150 bytes from the file
@@ -6495,15 +6418,15 @@ module.exports = function generate_multipleOf(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 402:
-/***/ (function(module, __unusedexports, __nested_webpack_require_202661__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = Octokit
 
-const endpoint = __nested_webpack_require_202661__(918).endpoint
-const Hook = __nested_webpack_require_202661__(523)
+const endpoint = __webpack_require__(918).endpoint
+const Hook = __webpack_require__(523)
 
-const parseClientOptions = __nested_webpack_require_202661__(294)
-const requestWithDefaults = __nested_webpack_require_202661__(878)
+const parseClientOptions = __webpack_require__(294)
+const requestWithDefaults = __webpack_require__(878)
 
 function Octokit (plugins, options) {
   options = options || {}
@@ -6531,18 +6454,18 @@ function Octokit (plugins, options) {
 /***/ 413:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(413);
+module.exports = require("stream");
 
 /***/ }),
 
 /***/ 417:
-/***/ (function(module, __unusedexports, __nested_webpack_require_203510__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var ruleModules = __nested_webpack_require_203510__(383)
-  , toHash = __nested_webpack_require_203510__(949).toHash;
+var ruleModules = __webpack_require__(383)
+  , toHash = __webpack_require__(949).toHash;
 
 module.exports = function rules() {
   var RULES = [
@@ -6610,13 +6533,13 @@ module.exports = function rules() {
 /***/ }),
 
 /***/ 427:
-/***/ (function(module, __unusedexports, __nested_webpack_require_205633__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 // Older verions of Node.js might not have `util.getSystemErrorName()`.
 // In that case, fall back to a deprecated internal.
-const util = __nested_webpack_require_205633__(669);
+const util = __webpack_require__(669);
 
 let uv;
 
@@ -6657,12 +6580,12 @@ function errname(uv, code) {
 /***/ }),
 
 /***/ 429:
-/***/ (function(__unusedmodule, exports, __nested_webpack_require_206573__) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const lib_1 = __nested_webpack_require_206573__(387);
+const lib_1 = __webpack_require__(387);
 process.on("unhandledRejection", (err) => {
     console.error(err, "error");
     throw new Error(`Exiting due to unhandled promise rejection`);
@@ -6673,11 +6596,11 @@ lib_1.run();
 /***/ }),
 
 /***/ 430:
-/***/ (function(module, __unusedexports, __nested_webpack_require_206941__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = octokitValidate
 
-const validate = __nested_webpack_require_206941__(348)
+const validate = __webpack_require__(348)
 
 function octokitValidate (octokit) {
   octokit.hook.before('request', validate)
@@ -6687,12 +6610,12 @@ function octokitValidate (octokit) {
 /***/ }),
 
 /***/ 431:
-/***/ (function(__unusedmodule, exports, __nested_webpack_require_207189__) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const os = __nested_webpack_require_207189__(87);
+const os = __webpack_require__(87);
 /**
  * Commands
  *
@@ -6854,11 +6777,11 @@ module.exports = function generate_uniqueItems(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 453:
-/***/ (function(module, __unusedexports, __nested_webpack_require_213159__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-var once = __nested_webpack_require_213159__(969)
-var eos = __nested_webpack_require_213159__(9)
-var fs = __nested_webpack_require_213159__(747) // we only need fs to get the ReadStream and WriteStream prototypes
+var once = __webpack_require__(969)
+var eos = __webpack_require__(9)
+var fs = __webpack_require__(747) // we only need fs to get the ReadStream and WriteStream prototypes
 
 var noop = function () {}
 var ancient = /^v?\.0/.test(process.version)
@@ -6943,7 +6866,7 @@ module.exports = pump
 /***/ }),
 
 /***/ 454:
-/***/ (function(module, exports, __nested_webpack_require_215482__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
@@ -6952,11 +6875,11 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var Stream = _interopDefault(__nested_webpack_require_215482__(413));
-var http = _interopDefault(__nested_webpack_require_215482__(605));
-var Url = _interopDefault(__nested_webpack_require_215482__(835));
-var https = _interopDefault(__nested_webpack_require_215482__(211));
-var zlib = _interopDefault(__nested_webpack_require_215482__(761));
+var Stream = _interopDefault(__webpack_require__(413));
+var http = _interopDefault(__webpack_require__(605));
+var Url = _interopDefault(__webpack_require__(835));
+var https = _interopDefault(__webpack_require__(211));
+var zlib = _interopDefault(__webpack_require__(761));
 
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 
@@ -7107,7 +7030,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = __nested_webpack_require_215482__(18).convert;
+	convert = __webpack_require__(18).convert;
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -8646,7 +8569,7 @@ module.exports.argument = escapeArgument;
 /***/ }),
 
 /***/ 469:
-/***/ (function(__unusedmodule, exports, __nested_webpack_require_258171__) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
@@ -8662,9 +8585,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 // Originally pulled from https://github.com/JasonEtco/actions-toolkit/blob/master/src/github.ts
-const graphql_1 = __nested_webpack_require_258171__(503);
-const rest_1 = __importDefault(__nested_webpack_require_258171__(613));
-const Context = __importStar(__nested_webpack_require_258171__(262));
+const graphql_1 = __webpack_require__(503);
+const rest_1 = __importDefault(__webpack_require__(613));
+const Context = __importStar(__webpack_require__(262));
 // We need this in order to extend Octokit
 rest_1.default.prototype = new rest_1.default();
 exports.context = new Context.Context();
@@ -8682,7 +8605,7 @@ exports.GitHub = GitHub;
 /***/ }),
 
 /***/ 470:
-/***/ (function(__unusedmodule, exports, __nested_webpack_require_259484__) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
@@ -8696,9 +8619,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const command_1 = __nested_webpack_require_259484__(431);
-const os = __nested_webpack_require_259484__(87);
-const path = __nested_webpack_require_259484__(622);
+const command_1 = __webpack_require__(431);
+const os = __webpack_require__(87);
+const path = __webpack_require__(622);
 /**
  * The code to exit an action
  */
@@ -8884,12 +8807,12 @@ exports.getState = getState;
 /***/ }),
 
 /***/ 471:
-/***/ (function(module, __unusedexports, __nested_webpack_require_265486__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = authenticationBeforeRequest
 
-const btoa = __nested_webpack_require_265486__(675)
-const uniq = __nested_webpack_require_265486__(126)
+const btoa = __webpack_require__(675)
+const uniq = __webpack_require__(126)
 
 function authenticationBeforeRequest (state, options) {
   if (!state.auth.type) {
@@ -8931,14 +8854,14 @@ function authenticationBeforeRequest (state, options) {
 /***/ }),
 
 /***/ 474:
-/***/ (function(module, __unusedexports, __nested_webpack_require_266764__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = toRequestOptions
 
-const urlTemplate = __nested_webpack_require_266764__(714)
-const addQueryParameters = __nested_webpack_require_266764__(293)
-const extractUrlVariableNames = __nested_webpack_require_266764__(838)
-const omit = __nested_webpack_require_266764__(302)
+const urlTemplate = __webpack_require__(714)
+const addQueryParameters = __webpack_require__(293)
+const extractUrlVariableNames = __webpack_require__(838)
+const omit = __webpack_require__(302)
 
 function toRequestOptions (options) {
   // https://fetch.spec.whatwg.org/#methods
@@ -9020,14 +8943,14 @@ function toRequestOptions (options) {
 /***/ }),
 
 /***/ 489:
-/***/ (function(module, __unusedexports, __nested_webpack_require_269895__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-const path = __nested_webpack_require_269895__(622);
-const which = __nested_webpack_require_269895__(814);
-const pathKey = __nested_webpack_require_269895__(39)();
+const path = __webpack_require__(622);
+const which = __webpack_require__(814);
+const pathKey = __webpack_require__(39)();
 
 function resolveCommandAttempt(parsed, withoutPathExt) {
     const cwd = process.cwd();
@@ -9075,12 +8998,12 @@ module.exports = resolveCommand;
 /***/ }),
 
 /***/ 492:
-/***/ (function(module, __unusedexports, __nested_webpack_require_271333__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var util = __nested_webpack_require_271333__(949);
+var util = __webpack_require__(949);
 
 module.exports = SchemaObject;
 
@@ -9092,11 +9015,11 @@ function SchemaObject(obj) {
 /***/ }),
 
 /***/ 500:
-/***/ (function(module, __unusedexports, __nested_webpack_require_271563__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = graphql
 
-const GraphqlError = __nested_webpack_require_271563__(862)
+const GraphqlError = __webpack_require__(862)
 
 const NON_VARIABLE_OPTIONS = ['method', 'baseUrl', 'url', 'headers', 'request', 'query']
 
@@ -9135,15 +9058,15 @@ function graphql (request, query, options) {
 /***/ }),
 
 /***/ 503:
-/***/ (function(module, __unusedexports, __nested_webpack_require_272486__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-const request = __nested_webpack_require_272486__(649)
-const getUserAgent = __nested_webpack_require_272486__(46)
+const request = __webpack_require__(649)
+const getUserAgent = __webpack_require__(46)
 
-const version = __nested_webpack_require_272486__(314).version
+const version = __webpack_require__(314).version
 const userAgent = `octokit-graphql.js/${version} ${getUserAgent()}`
 
-const withDefaults = __nested_webpack_require_272486__(0)
+const withDefaults = __webpack_require__(0)
 
 module.exports = withDefaults(request, {
   method: 'POST',
@@ -9159,7 +9082,7 @@ module.exports = withDefaults(request, {
 /***/ 509:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/request@2.4.2","/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks"]],"_from":"@octokit/request@2.4.2","_id":"@octokit/request@2.4.2","_inBundle":false,"_integrity":"sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==","_location":"/@octokit/request","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/request@2.4.2","name":"@octokit/request","escapedName":"@octokit%2frequest","scope":"@octokit","rawSpec":"2.4.2","saveSpec":null,"fetchSpec":"2.4.2"},"_requiredBy":["/@octokit/graphql"],"_resolved":"https://registry.npmjs.org/@octokit/request/-/request-2.4.2.tgz","_spec":"2.4.2","_where":"/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"browser":{"./lib/get-request-agent.js":false,"./lib/request/get-buffer-response.js":"./lib/request/get-buffer-response-browser.js"},"bugs":{"url":"https://github.com/octokit/request.js/issues"},"bundlesize":[{"path":"./dist/octokit-request.min.js.gz","maxSize":"5KB"}],"dependencies":{"@octokit/endpoint":"^3.2.0","deprecation":"^1.0.1","is-plain-object":"^2.0.4","node-fetch":"^2.3.0","once":"^1.4.0","universal-user-agent":"^2.0.1"},"description":"Send parameterized requests to GitHub’s APIs with sensible defaults in browsers and Node","devDependencies":{"chai":"^4.2.0","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.2","cypress":"^3.1.0","fetch-mock":"^7.2.0","mkdirp":"^0.5.1","mocha":"^6.0.0","npm-run-all":"^4.1.3","nyc":"^13.1.0","semantic-release":"^15.10.5","simple-mock":"^0.8.0","standard":"^12.0.1","webpack":"^4.22.0","webpack-bundle-analyzer":"^3.0.3","webpack-cli":"^3.1.2"},"files":["lib"],"homepage":"https://github.com/octokit/request.js#readme","keywords":["octokit","github","api","request"],"license":"MIT","main":"index.js","name":"@octokit/request","publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/request.js.git"},"scripts":{"build":"npm-run-all build:*","build:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-request.js --profile --json > dist/bundle-stats.json","build:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-request.min.js --devtool source-map","bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","prebuild":"mkdirp dist/","pretest":"standard","semantic-release":"semantic-release","test":"nyc mocha test/*-test.js","test:browser":"cypress run --browser chrome"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect"]},"version":"2.4.2"};
+module.exports = {"_args":[["@octokit/request@2.4.2","/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action"]],"_from":"@octokit/request@2.4.2","_id":"@octokit/request@2.4.2","_inBundle":false,"_integrity":"sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==","_location":"/@octokit/request","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/request@2.4.2","name":"@octokit/request","escapedName":"@octokit%2frequest","scope":"@octokit","rawSpec":"2.4.2","saveSpec":null,"fetchSpec":"2.4.2"},"_requiredBy":["/@octokit/graphql"],"_resolved":"https://registry.npmjs.org/@octokit/request/-/request-2.4.2.tgz","_spec":"2.4.2","_where":"/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"browser":{"./lib/get-request-agent.js":false,"./lib/request/get-buffer-response.js":"./lib/request/get-buffer-response-browser.js"},"bugs":{"url":"https://github.com/octokit/request.js/issues"},"bundlesize":[{"path":"./dist/octokit-request.min.js.gz","maxSize":"5KB"}],"dependencies":{"@octokit/endpoint":"^3.2.0","deprecation":"^1.0.1","is-plain-object":"^2.0.4","node-fetch":"^2.3.0","once":"^1.4.0","universal-user-agent":"^2.0.1"},"description":"Send parameterized requests to GitHub’s APIs with sensible defaults in browsers and Node","devDependencies":{"chai":"^4.2.0","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.2","cypress":"^3.1.0","fetch-mock":"^7.2.0","mkdirp":"^0.5.1","mocha":"^6.0.0","npm-run-all":"^4.1.3","nyc":"^13.1.0","semantic-release":"^15.10.5","simple-mock":"^0.8.0","standard":"^12.0.1","webpack":"^4.22.0","webpack-bundle-analyzer":"^3.0.3","webpack-cli":"^3.1.2"},"files":["lib"],"homepage":"https://github.com/octokit/request.js#readme","keywords":["octokit","github","api","request"],"license":"MIT","main":"index.js","name":"@octokit/request","publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/request.js.git"},"scripts":{"build":"npm-run-all build:*","build:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-request.js --profile --json > dist/bundle-stats.json","build:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-request.min.js --devtool source-map","bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","prebuild":"mkdirp dist/","pretest":"standard","semantic-release":"semantic-release","test":"nyc mocha test/*-test.js","test:browser":"cypress run --browser chrome"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect"]},"version":"2.4.2"};
 
 /***/ }),
 
@@ -9217,20 +9140,20 @@ function addHook (state, kind, name, hook) {
 /***/ }),
 
 /***/ 514:
-/***/ (function(module, __unusedexports, __nested_webpack_require_277156__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var compileSchema = __nested_webpack_require_277156__(805)
-  , resolve = __nested_webpack_require_277156__(867)
-  , Cache = __nested_webpack_require_277156__(921)
-  , SchemaObject = __nested_webpack_require_277156__(492)
-  , stableStringify = __nested_webpack_require_277156__(741)
-  , formats = __nested_webpack_require_277156__(635)
-  , rules = __nested_webpack_require_277156__(417)
-  , $dataMetaSchema = __nested_webpack_require_277156__(628)
-  , util = __nested_webpack_require_277156__(949);
+var compileSchema = __webpack_require__(805)
+  , resolve = __webpack_require__(867)
+  , Cache = __webpack_require__(921)
+  , SchemaObject = __webpack_require__(492)
+  , stableStringify = __webpack_require__(741)
+  , formats = __webpack_require__(635)
+  , rules = __webpack_require__(417)
+  , $dataMetaSchema = __webpack_require__(628)
+  , util = __webpack_require__(949);
 
 module.exports = Ajv;
 
@@ -9247,14 +9170,14 @@ Ajv.prototype.errorsText = errorsText;
 Ajv.prototype._addSchema = _addSchema;
 Ajv.prototype._compile = _compile;
 
-Ajv.prototype.compileAsync = __nested_webpack_require_277156__(890);
-var customKeyword = __nested_webpack_require_277156__(45);
+Ajv.prototype.compileAsync = __webpack_require__(890);
+var customKeyword = __webpack_require__(45);
 Ajv.prototype.addKeyword = customKeyword.add;
 Ajv.prototype.getKeyword = customKeyword.get;
 Ajv.prototype.removeKeyword = customKeyword.remove;
 Ajv.prototype.validateKeyword = customKeyword.validate;
 
-var errorClasses = __nested_webpack_require_277156__(844);
+var errorClasses = __webpack_require__(844);
 Ajv.ValidationError = errorClasses.Validation;
 Ajv.MissingRefError = errorClasses.MissingRef;
 Ajv.$dataMetaSchema = $dataMetaSchema;
@@ -9663,11 +9586,11 @@ function addFormat(name, format) {
 function addDefaultMetaSchema(self) {
   var $dataSchema;
   if (self._opts.$data) {
-    $dataSchema = __nested_webpack_require_277156__(339);
+    $dataSchema = __webpack_require__(339);
     self.addMetaSchema($dataSchema, $dataSchema.$id, true);
   }
   if (self._opts.meta === false) return;
-  var metaSchema = __nested_webpack_require_277156__(522);
+  var metaSchema = __webpack_require__(522);
   if (self._opts.$data) metaSchema = $dataMetaSchema(metaSchema, META_SUPPORT_DATA);
   self.addMetaSchema(metaSchema, META_SCHEMA_ID, true);
   self._refs['http://json-schema.org/schema'] = META_SCHEMA_ID;
@@ -9738,11 +9661,11 @@ module.exports = {"$schema":"http://json-schema.org/draft-07/schema#","$id":"htt
 /***/ }),
 
 /***/ 523:
-/***/ (function(module, __unusedexports, __nested_webpack_require_295879__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-var register = __nested_webpack_require_295879__(363)
-var addHook = __nested_webpack_require_295879__(510)
-var removeHook = __nested_webpack_require_295879__(763)
+var register = __webpack_require__(363)
+var addHook = __webpack_require__(510)
+var removeHook = __webpack_require__(763)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -9803,9 +9726,9 @@ module.exports.Collection = Hook.Collection
 /***/ }),
 
 /***/ 529:
-/***/ (function(module, __unusedexports, __nested_webpack_require_297783__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-const factory = __nested_webpack_require_297783__(47)
+const factory = __webpack_require__(47)
 
 module.exports = factory()
 
@@ -9813,12 +9736,12 @@ module.exports = factory()
 /***/ }),
 
 /***/ 536:
-/***/ (function(module, __unusedexports, __nested_webpack_require_297940__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = hasFirstPage
 
-const deprecate = __nested_webpack_require_297940__(370)
-const getPageLinks = __nested_webpack_require_297940__(577)
+const deprecate = __webpack_require__(370)
+const getPageLinks = __webpack_require__(577)
 
 function hasFirstPage (link) {
   deprecate(`octokit.hasFirstPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -9912,11 +9835,11 @@ module.exports = function generate_pattern(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 550:
-/***/ (function(module, __unusedexports, __nested_webpack_require_300999__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = getNextPage
 
-const getPage = __nested_webpack_require_300999__(265)
+const getPage = __webpack_require__(265)
 
 function getNextPage (octokit, link, headers) {
   return getPage(octokit, link, 'next', headers)
@@ -9926,12 +9849,12 @@ function getNextPage (octokit, link, headers) {
 /***/ }),
 
 /***/ 558:
-/***/ (function(module, __unusedexports, __nested_webpack_require_301259__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = hasPreviousPage
 
-const deprecate = __nested_webpack_require_301259__(370)
-const getPageLinks = __nested_webpack_require_301259__(577)
+const deprecate = __webpack_require__(370)
+const getPageLinks = __webpack_require__(577)
 
 function hasPreviousPage (link) {
   deprecate(`octokit.hasPreviousPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -10030,11 +9953,11 @@ module.exports = function generate__limitProperties(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 563:
-/***/ (function(module, __unusedexports, __nested_webpack_require_304482__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = getPreviousPage
 
-const getPage = __nested_webpack_require_304482__(265)
+const getPage = __webpack_require__(265)
 
 function getPreviousPage (octokit, link, headers) {
   return getPage(octokit, link, 'prev', headers)
@@ -10133,17 +10056,17 @@ module.exports = function generate_propertyNames(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 568:
-/***/ (function(module, __unusedexports, __nested_webpack_require_308386__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-const path = __nested_webpack_require_308386__(622);
-const niceTry = __nested_webpack_require_308386__(948);
-const resolveCommand = __nested_webpack_require_308386__(489);
-const escape = __nested_webpack_require_308386__(462);
-const readShebang = __nested_webpack_require_308386__(389);
-const semver = __nested_webpack_require_308386__(280);
+const path = __webpack_require__(622);
+const niceTry = __webpack_require__(948);
+const resolveCommand = __webpack_require__(489);
+const escape = __webpack_require__(462);
+const readShebang = __webpack_require__(389);
+const semver = __webpack_require__(280);
 
 const isWin = process.platform === 'win32';
 const isExecutableRegExp = /\.(?:com|exe)$/i;
@@ -10307,10 +10230,10 @@ function getPageLinks (link) {
 /***/ }),
 
 /***/ 585:
-/***/ (function(module, __unusedexports, __nested_webpack_require_313630__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-const withDefaults = __nested_webpack_require_313630__(118)
-const DEFAULTS = __nested_webpack_require_313630__(307)
+const withDefaults = __webpack_require__(118)
+const DEFAULTS = __webpack_require__(307)
 
 module.exports = withDefaults(null, DEFAULTS)
 
@@ -10318,11 +10241,11 @@ module.exports = withDefaults(null, DEFAULTS)
 /***/ }),
 
 /***/ 586:
-/***/ (function(module, __unusedexports, __nested_webpack_require_313854__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = octokitRestApiEndpoints
 
-const ROUTES = __nested_webpack_require_313854__(705)
+const ROUTES = __webpack_require__(705)
 
 function octokitRestApiEndpoints (octokit) {
   // Aliasing scopes for backward compatibility
@@ -10340,25 +10263,25 @@ function octokitRestApiEndpoints (octokit) {
 /***/ 605:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(605);
+module.exports = require("http");
 
 /***/ }),
 
 /***/ 613:
-/***/ (function(module, __unusedexports, __nested_webpack_require_314415__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-const Octokit = __nested_webpack_require_314415__(529)
+const Octokit = __webpack_require__(529)
 
 const CORE_PLUGINS = [
-  __nested_webpack_require_314415__(372),
-  __nested_webpack_require_314415__(19), // deprecated: remove in v17
-  __nested_webpack_require_314415__(190),
-  __nested_webpack_require_314415__(148),
-  __nested_webpack_require_314415__(248),
-  __nested_webpack_require_314415__(586),
-  __nested_webpack_require_314415__(430),
+  __webpack_require__(372),
+  __webpack_require__(19), // deprecated: remove in v17
+  __webpack_require__(190),
+  __webpack_require__(148),
+  __webpack_require__(248),
+  __webpack_require__(586),
+  __webpack_require__(430),
 
-  __nested_webpack_require_314415__(850) // deprecated: remove in v17
+  __webpack_require__(850) // deprecated: remove in v17
 ]
 
 module.exports = Octokit.plugin(CORE_PLUGINS)
@@ -10369,17 +10292,17 @@ module.exports = Octokit.plugin(CORE_PLUGINS)
 /***/ 614:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(614);
+module.exports = require("events");
 
 /***/ }),
 
 /***/ 621:
-/***/ (function(module, __unusedexports, __nested_webpack_require_314985__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
-const path = __nested_webpack_require_314985__(622);
-const pathKey = __nested_webpack_require_314985__(39);
+const path = __webpack_require__(622);
+const pathKey = __webpack_require__(39);
 
 module.exports = opts => {
 	opts = Object.assign({
@@ -10423,7 +10346,7 @@ module.exports.env = opts => {
 /***/ 622:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(622);
+module.exports = require("path");
 
 /***/ }),
 
@@ -10485,12 +10408,12 @@ module.exports = function (metaSchema, keywordsJsonPointers) {
 /***/ }),
 
 /***/ 635:
-/***/ (function(module, __unusedexports, __nested_webpack_require_317038__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var util = __nested_webpack_require_317038__(949);
+var util = __webpack_require__(949);
 
 var DATE = /^(\d\d\d\d)-(\d\d)-(\d\d)$/;
 var DAYS = [0,31,28,31,30,31,30,31,31,30,31,30,31];
@@ -10783,14 +10706,14 @@ module.exports = function generate_items(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 649:
-/***/ (function(module, __unusedexports, __nested_webpack_require_335419__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-const endpoint = __nested_webpack_require_335419__(585)
-const getUserAgent = __nested_webpack_require_335419__(46)
+const endpoint = __webpack_require__(585)
+const getUserAgent = __webpack_require__(46)
 
-const version = __nested_webpack_require_335419__(509).version
+const version = __webpack_require__(509).version
 const userAgent = `octokit-request.js/${version} ${getUserAgent()}`
-const withDefaults = __nested_webpack_require_335419__(242)
+const withDefaults = __webpack_require__(242)
 
 module.exports = withDefaults(endpoint, {
   headers: {
@@ -11120,7 +11043,7 @@ module.exports = function generate_const(it, $keyword, $ruleType) {
 /***/ 669:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(669);
+module.exports = require("util");
 
 /***/ }),
 
@@ -11683,7 +11606,7 @@ module.exports = {"activity":{"checkStarringRepo":{"method":"GET","params":{"own
 /***/ 724:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/endpoint@3.2.3","/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks"]],"_from":"@octokit/endpoint@3.2.3","_id":"@octokit/endpoint@3.2.3","_inBundle":false,"_integrity":"sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==","_location":"/@octokit/endpoint","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/endpoint@3.2.3","name":"@octokit/endpoint","escapedName":"@octokit%2fendpoint","scope":"@octokit","rawSpec":"3.2.3","saveSpec":null,"fetchSpec":"3.2.3"},"_requiredBy":["/@octokit/request","/@octokit/rest/@octokit/request"],"_resolved":"https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.2.3.tgz","_spec":"3.2.3","_where":"/Users/diegocisneros/Projects/coding/hypothesize/diego-ci-checks","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/endpoint.js/issues"},"bundlesize":[{"path":"./dist/octokit-endpoint.min.js.gz","maxSize":"3.5KB"}],"dependencies":{"deepmerge":"3.2.0","is-plain-object":"^2.0.4","universal-user-agent":"^2.0.1","url-template":"^2.0.8"},"description":"Turns REST API endpoints into generic request options","devDependencies":{"chai":"^4.2.0","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.2","cypress":"^3.1.0","mkdirp":"^0.5.1","mocha":"^6.0.2","npm-run-all":"^4.1.3","nyc":"^13.1.0","semantic-release":"^15.10.3","sinon-chai":"^3.2.0","standard":"^12.0.1","standard-markdown":"^5.0.1","webpack":"^4.21.0","webpack-bundle-analyzer":"^3.0.3","webpack-cli":"^3.1.2"},"directories":{"test":"test"},"files":["lib","with-defaults.js"],"homepage":"https://github.com/octokit/endpoint.js#readme","keywords":["octokit","github","api","rest"],"license":"MIT","main":"index.js","name":"@octokit/endpoint","publishConfig":{"access":"public","tag":"latest"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/endpoint.js.git"},"scripts":{"build":"npm-run-all build:*","build:development":"webpack --mode development --entry . --output-library=octokitEndpoint --output=./dist/octokit-endpoint.js --profile --json > dist/bundle-stats.json","build:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=octokitEndpoint --output-path=./dist --output-filename=octokit-endpoint.min.js --devtool source-map","bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","prebuild":"mkdirp dist/","pretest":"standard && standard-markdown *.md","semantic-release":"semantic-release","test":"nyc mocha test/*-test.js","test:browser":"cypress run --browser chrome"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect"]},"version":"3.2.3"};
+module.exports = {"_args":[["@octokit/endpoint@3.2.3","/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action"]],"_from":"@octokit/endpoint@3.2.3","_id":"@octokit/endpoint@3.2.3","_inBundle":false,"_integrity":"sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==","_location":"/@octokit/endpoint","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"@octokit/endpoint@3.2.3","name":"@octokit/endpoint","escapedName":"@octokit%2fendpoint","scope":"@octokit","rawSpec":"3.2.3","saveSpec":null,"fetchSpec":"3.2.3"},"_requiredBy":["/@octokit/request","/@octokit/rest/@octokit/request"],"_resolved":"https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.2.3.tgz","_spec":"3.2.3","_where":"/home/eltharim/Dropbox/ArthurP+Hypothesize/Repositories/ci-checks-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/endpoint.js/issues"},"bundlesize":[{"path":"./dist/octokit-endpoint.min.js.gz","maxSize":"3.5KB"}],"dependencies":{"deepmerge":"3.2.0","is-plain-object":"^2.0.4","universal-user-agent":"^2.0.1","url-template":"^2.0.8"},"description":"Turns REST API endpoints into generic request options","devDependencies":{"chai":"^4.2.0","compression-webpack-plugin":"^2.0.0","coveralls":"^3.0.2","cypress":"^3.1.0","mkdirp":"^0.5.1","mocha":"^6.0.2","npm-run-all":"^4.1.3","nyc":"^13.1.0","semantic-release":"^15.10.3","sinon-chai":"^3.2.0","standard":"^12.0.1","standard-markdown":"^5.0.1","webpack":"^4.21.0","webpack-bundle-analyzer":"^3.0.3","webpack-cli":"^3.1.2"},"directories":{"test":"test"},"files":["lib","with-defaults.js"],"homepage":"https://github.com/octokit/endpoint.js#readme","keywords":["octokit","github","api","rest"],"license":"MIT","main":"index.js","name":"@octokit/endpoint","publishConfig":{"access":"public","tag":"latest"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/endpoint.js.git"},"scripts":{"build":"npm-run-all build:*","build:development":"webpack --mode development --entry . --output-library=octokitEndpoint --output=./dist/octokit-endpoint.js --profile --json > dist/bundle-stats.json","build:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=octokitEndpoint --output-path=./dist --output-filename=octokit-endpoint.min.js --devtool source-map","bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","coverage":"nyc report --reporter=html && open coverage/index.html","coverage:upload":"nyc report --reporter=text-lcov | coveralls","prebuild":"mkdirp dist/","pretest":"standard && standard-markdown *.md","semantic-release":"semantic-release","test":"nyc mocha test/*-test.js","test:browser":"cypress run --browser chrome"},"standard":{"globals":["describe","before","beforeEach","afterEach","after","it","expect"]},"version":"3.2.3"};
 
 /***/ }),
 
@@ -11755,14 +11678,14 @@ module.exports = function (data, opts) {
 /***/ }),
 
 /***/ 742:
-/***/ (function(module, __unusedexports, __nested_webpack_require_496602__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = defaultOptions
 
-const merge = __nested_webpack_require_496602__(278)
-const isPlainObject = __nested_webpack_require_496602__(960)
+const merge = __webpack_require__(278)
+const isPlainObject = __webpack_require__(960)
 
-const lowercaseKeys = __nested_webpack_require_496602__(571)
+const lowercaseKeys = __webpack_require__(571)
 
 function defaultOptions (defaults, route, options) {
   if (typeof route === 'string') {
@@ -11794,20 +11717,20 @@ function defaultOptions (defaults, route, options) {
 /***/ 747:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(747);
+module.exports = require("fs");
 
 /***/ }),
 
 /***/ 755:
-/***/ (function(module, __unusedexports, __nested_webpack_require_497838__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = request
 
-const isPlainObject = __nested_webpack_require_497838__(960)
-const nodeFetch = __nested_webpack_require_497838__(454).default
+const isPlainObject = __webpack_require__(960)
+const nodeFetch = __webpack_require__(454).default
 
-const getBuffer = __nested_webpack_require_497838__(163)
-const HttpError = __nested_webpack_require_497838__(277)
+const getBuffer = __webpack_require__(163)
+const HttpError = __webpack_require__(277)
 
 function request (requestOptions) {
   if (isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
@@ -11904,7 +11827,7 @@ function request (requestOptions) {
 /***/ 761:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(761);
+module.exports = require("zlib");
 
 /***/ }),
 
@@ -12055,11 +11978,11 @@ module.exports = function generate__limitLength(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 777:
-/***/ (function(module, __unusedexports, __nested_webpack_require_504107__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = getFirstPage
 
-const getPage = __nested_webpack_require_504107__(265)
+const getPage = __webpack_require__(265)
 
 function getFirstPage (octokit, link, headers) {
   return getPage(octokit, link, 'first', headers)
@@ -12089,24 +12012,24 @@ module.exports = function isObject(val) {
 /***/ }),
 
 /***/ 805:
-/***/ (function(module, __unusedexports, __nested_webpack_require_504710__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var resolve = __nested_webpack_require_504710__(867)
-  , util = __nested_webpack_require_504710__(949)
-  , errorClasses = __nested_webpack_require_504710__(844)
-  , stableStringify = __nested_webpack_require_504710__(741);
+var resolve = __webpack_require__(867)
+  , util = __webpack_require__(949)
+  , errorClasses = __webpack_require__(844)
+  , stableStringify = __webpack_require__(741);
 
-var validateGenerator = __nested_webpack_require_504710__(967);
+var validateGenerator = __webpack_require__(967);
 
 /**
  * Functions below are used inside compiled validations function
  */
 
 var ucs2length = util.ucs2length;
-var equal = __nested_webpack_require_504710__(930);
+var equal = __webpack_require__(930);
 
 // this error is thrown by async schemas to return validation errors via exception
 var ValidationError = errorClasses.Validation;
@@ -12484,11 +12407,11 @@ function vars(arr, statement) {
 /***/ }),
 
 /***/ 807:
-/***/ (function(module, __unusedexports, __nested_webpack_require_515485__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = paginate
 
-const iterator = __nested_webpack_require_515485__(8)
+const iterator = __webpack_require__(8)
 
 function paginate (octokit, route, options, mapFn) {
   if (typeof options === 'function') {
@@ -12525,14 +12448,14 @@ function gather (results, iterator, mapFn) {
 /***/ }),
 
 /***/ 813:
-/***/ (function(module, __unusedexports, __nested_webpack_require_516356__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-var fs = __nested_webpack_require_516356__(747)
+var fs = __webpack_require__(747)
 var core
 if (process.platform === 'win32' || global.TESTING_WINDOWS) {
-  core = __nested_webpack_require_516356__(818)
+  core = __webpack_require__(818)
 } else {
-  core = __nested_webpack_require_516356__(197)
+  core = __webpack_require__(197)
 }
 
 module.exports = isexe
@@ -12589,7 +12512,7 @@ function sync (path, options) {
 /***/ }),
 
 /***/ 814:
-/***/ (function(module, __unusedexports, __nested_webpack_require_517653__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = which
 which.sync = whichSync
@@ -12598,9 +12521,9 @@ var isWindows = process.platform === 'win32' ||
     process.env.OSTYPE === 'cygwin' ||
     process.env.OSTYPE === 'msys'
 
-var path = __nested_webpack_require_517653__(622)
+var path = __webpack_require__(622)
 var COLON = isWindows ? ';' : ':'
-var isexe = __nested_webpack_require_517653__(813)
+var isexe = __webpack_require__(813)
 
 function getNotFoundError (cmd) {
   var er = new Error('not found: ' + cmd)
@@ -12741,12 +12664,12 @@ module.exports = /^#!.*/;
 /***/ }),
 
 /***/ 818:
-/***/ (function(module, __unusedexports, __nested_webpack_require_521035__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = isexe
 isexe.sync = sync
 
-var fs = __nested_webpack_require_521035__(747)
+var fs = __webpack_require__(747)
 
 function checkPathExt (path, options) {
   var pathext = options.pathExt !== undefined ?
@@ -12814,7 +12737,7 @@ module.exports = module.exports.Deprecation = Deprecation
 /***/ 835:
 /***/ (function(module) {
 
-module.exports = __webpack_require__(835);
+module.exports = require("url");
 
 /***/ }),
 
@@ -12842,12 +12765,12 @@ function removeNonChars (variableName) {
 /***/ }),
 
 /***/ 844:
-/***/ (function(module, __unusedexports, __nested_webpack_require_522950__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var resolve = __nested_webpack_require_522950__(867);
+var resolve = __webpack_require__(867);
 
 module.exports = {
   Validation: errorSubclass(ValidationError),
@@ -12884,19 +12807,19 @@ function errorSubclass(Subclass) {
 /***/ }),
 
 /***/ 850:
-/***/ (function(module, __unusedexports, __nested_webpack_require_523872__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = paginationMethodsPlugin
 
 function paginationMethodsPlugin (octokit) {
-  octokit.getFirstPage = __nested_webpack_require_523872__(777).bind(null, octokit)
-  octokit.getLastPage = __nested_webpack_require_523872__(30).bind(null, octokit)
-  octokit.getNextPage = __nested_webpack_require_523872__(550).bind(null, octokit)
-  octokit.getPreviousPage = __nested_webpack_require_523872__(563).bind(null, octokit)
-  octokit.hasFirstPage = __nested_webpack_require_523872__(536)
-  octokit.hasLastPage = __nested_webpack_require_523872__(336)
-  octokit.hasNextPage = __nested_webpack_require_523872__(929)
-  octokit.hasPreviousPage = __nested_webpack_require_523872__(558)
+  octokit.getFirstPage = __webpack_require__(777).bind(null, octokit)
+  octokit.getLastPage = __webpack_require__(30).bind(null, octokit)
+  octokit.getNextPage = __webpack_require__(550).bind(null, octokit)
+  octokit.getPreviousPage = __webpack_require__(563).bind(null, octokit)
+  octokit.hasFirstPage = __webpack_require__(536)
+  octokit.hasLastPage = __webpack_require__(336)
+  octokit.hasNextPage = __webpack_require__(929)
+  octokit.hasPreviousPage = __webpack_require__(558)
 }
 
 
@@ -15236,11 +15159,11 @@ module.exports = get;
 /***/ }),
 
 /***/ 855:
-/***/ (function(module, __unusedexports, __nested_webpack_require_603100__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = registerPlugin
 
-const factory = __nested_webpack_require_603100__(47)
+const factory = __webpack_require__(47)
 
 function registerPlugin (plugins, pluginFunction) {
   return factory(plugins.includes(pluginFunction) ? plugins : plugins.concat(pluginFunction))
@@ -15551,11 +15474,11 @@ module.exports = class GraphqlError extends Error {
 /***/ }),
 
 /***/ 863:
-/***/ (function(module, __unusedexports, __nested_webpack_require_616330__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = authenticationBeforeRequest
 
-const btoa = __nested_webpack_require_616330__(675)
+const btoa = __webpack_require__(675)
 
 function authenticationBeforeRequest (state, options) {
   if (typeof state.auth === 'string') {
@@ -15614,11 +15537,11 @@ function authenticationBeforeRequest (state, options) {
 /***/ }),
 
 /***/ 866:
-/***/ (function(module, __unusedexports, __nested_webpack_require_618648__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
-var shebangRegex = __nested_webpack_require_618648__(816);
+var shebangRegex = __webpack_require__(816);
 
 module.exports = function (str) {
 	var match = str.match(shebangRegex);
@@ -15641,16 +15564,16 @@ module.exports = function (str) {
 /***/ }),
 
 /***/ 867:
-/***/ (function(module, __unusedexports, __nested_webpack_require_619084__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var URI = __nested_webpack_require_619084__(853)
-  , equal = __nested_webpack_require_619084__(930)
-  , util = __nested_webpack_require_619084__(949)
-  , SchemaObject = __nested_webpack_require_619084__(492)
-  , traverse = __nested_webpack_require_619084__(340);
+var URI = __webpack_require__(853)
+  , equal = __webpack_require__(930)
+  , util = __webpack_require__(949)
+  , SchemaObject = __webpack_require__(492)
+  , traverse = __webpack_require__(340);
 
 module.exports = resolve;
 
@@ -15919,11 +15842,11 @@ function resolveIds(schema) {
 /***/ }),
 
 /***/ 878:
-/***/ (function(module, __unusedexports, __nested_webpack_require_627027__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = withDefaults
 
-const request = __nested_webpack_require_627027__(354)
+const request = __webpack_require__(354)
 
 function withDefaults (hook, oldEndpoint, newDefaults) {
   const endpoint = oldEndpoint.defaults(newDefaults)
@@ -17009,12 +16932,12 @@ module.exports = set;
 /***/ }),
 
 /***/ 890:
-/***/ (function(module, __unusedexports, __nested_webpack_require_654513__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var MissingRefError = __nested_webpack_require_654513__(844).MissingRef;
+var MissingRefError = __webpack_require__(844).MissingRef;
 
 module.exports = compileAsync;
 
@@ -17234,14 +17157,14 @@ module.exports = function generate_anyOf(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 918:
-/***/ (function(module, __unusedexports, __nested_webpack_require_661278__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-const endpoint = __nested_webpack_require_661278__(585)
-const getUserAgent = __nested_webpack_require_661278__(46)
+const endpoint = __webpack_require__(585)
+const getUserAgent = __webpack_require__(46)
 
-const version = __nested_webpack_require_661278__(41).version
+const version = __webpack_require__(41).version
 const userAgent = `octokit-request.js/${version} ${getUserAgent()}`
-const withDefaults = __nested_webpack_require_661278__(326)
+const withDefaults = __webpack_require__(326)
 
 module.exports = withDefaults(endpoint, {
   headers: {
@@ -17287,12 +17210,12 @@ Cache.prototype.clear = function Cache_clear() {
 /***/ }),
 
 /***/ 929:
-/***/ (function(module, __unusedexports, __nested_webpack_require_662169__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = hasNextPage
 
-const deprecate = __nested_webpack_require_662169__(370)
-const getPageLinks = __nested_webpack_require_662169__(577)
+const deprecate = __webpack_require__(370)
+const getPageLinks = __webpack_require__(577)
 
 function hasNextPage (link) {
   deprecate(`octokit.hasNextPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -17376,7 +17299,7 @@ module.exports = function(fn) {
 /***/ }),
 
 /***/ 949:
-/***/ (function(module, __unusedexports, __nested_webpack_require_664171__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
@@ -17390,8 +17313,8 @@ module.exports = {
   toHash: toHash,
   getProperty: getProperty,
   escapeQuotes: escapeQuotes,
-  equal: __nested_webpack_require_664171__(930),
-  ucs2length: __nested_webpack_require_664171__(691),
+  equal: __webpack_require__(930),
+  ucs2length: __webpack_require__(691),
   varOccurences: varOccurences,
   varReplace: varReplace,
   schemaHasRules: schemaHasRules,
@@ -17623,12 +17546,12 @@ function unescapeJsonPointer(str) {
 /***/ }),
 
 /***/ 952:
-/***/ (function(module, __unusedexports, __nested_webpack_require_671234__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
 
-var metaSchema = __nested_webpack_require_671234__(522);
+var metaSchema = __webpack_require__(522);
 
 module.exports = {
   $id: 'https://github.com/ajv-validator/ajv/blob/master/lib/definition_schema.js',
@@ -17696,21 +17619,21 @@ function validateAuth (auth) {
 /***/ }),
 
 /***/ 955:
-/***/ (function(module, __unusedexports, __nested_webpack_require_672578__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
-const path = __nested_webpack_require_672578__(622);
-const childProcess = __nested_webpack_require_672578__(129);
-const crossSpawn = __nested_webpack_require_672578__(20);
-const stripEof = __nested_webpack_require_672578__(768);
-const npmRunPath = __nested_webpack_require_672578__(621);
-const isStream = __nested_webpack_require_672578__(323);
-const _getStream = __nested_webpack_require_672578__(145);
-const pFinally = __nested_webpack_require_672578__(697);
-const onExit = __nested_webpack_require_672578__(260);
-const errname = __nested_webpack_require_672578__(427);
-const stdio = __nested_webpack_require_672578__(168);
+const path = __webpack_require__(622);
+const childProcess = __webpack_require__(129);
+const crossSpawn = __webpack_require__(20);
+const stripEof = __webpack_require__(768);
+const npmRunPath = __webpack_require__(621);
+const isStream = __webpack_require__(323);
+const _getStream = __webpack_require__(145);
+const pFinally = __webpack_require__(697);
+const onExit = __webpack_require__(260);
+const errname = __webpack_require__(427);
+const stdio = __webpack_require__(168);
 
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
@@ -18065,7 +17988,7 @@ module.exports.shellSync = (cmd, opts) => handleShell(module.exports.sync, cmd, 
 /***/ }),
 
 /***/ 960:
-/***/ (function(module, __unusedexports, __nested_webpack_require_680374__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 /*!
@@ -18077,7 +18000,7 @@ module.exports.shellSync = (cmd, opts) => handleShell(module.exports.sync, cmd, 
 
 
 
-var isObject = __nested_webpack_require_680374__(782);
+var isObject = __webpack_require__(782);
 
 function isObjectObject(o) {
   return isObject(o) === true
@@ -18110,11 +18033,11 @@ module.exports = function isPlainObject(o) {
 /***/ }),
 
 /***/ 964:
-/***/ (function(module, __unusedexports, __nested_webpack_require_681325__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
-const os = __nested_webpack_require_681325__(87);
+const os = __webpack_require__(87);
 
 const nameMap = new Map([
 	[20, ['Big Sur', '11']],
@@ -18154,11 +18077,11 @@ module.exports.default = macosRelease;
 /***/ }),
 
 /***/ 966:
-/***/ (function(module, __unusedexports, __nested_webpack_require_682250__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 "use strict";
 
-const {PassThrough} = __nested_webpack_require_682250__(413);
+const {PassThrough} = __webpack_require__(413);
 
 module.exports = options => {
 	options = Object.assign({}, options);
@@ -18711,9 +18634,9 @@ module.exports = function generate_validate(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 969:
-/***/ (function(module, __unusedexports, __nested_webpack_require_703482__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
-var wrappy = __nested_webpack_require_703482__(11)
+var wrappy = __webpack_require__(11)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -18772,11 +18695,11 @@ function getBufferResponse (response) {
 /***/ }),
 
 /***/ 991:
-/***/ (function(module, __unusedexports, __nested_webpack_require_704668__) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
 
 module.exports = authenticationRequestError
 
-const HttpError = __nested_webpack_require_704668__(261)
+const HttpError = __webpack_require__(261)
 
 function authenticationRequestError (state, error, options) {
   const otpRequired = /required/.test(error.headers['x-github-otp'] || '')
@@ -18805,59 +18728,6 @@ function authenticationRequestError (state, error, options) {
     })
 }
 
-
-/***/ })
-
-/******/ });
-
-/***/ }),
-
-/***/ 605:
-/***/ (function(module) {
-
-module.exports = require("http");
-
-/***/ }),
-
-/***/ 614:
-/***/ (function(module) {
-
-module.exports = require("events");
-
-/***/ }),
-
-/***/ 622:
-/***/ (function(module) {
-
-module.exports = require("path");
-
-/***/ }),
-
-/***/ 669:
-/***/ (function(module) {
-
-module.exports = require("util");
-
-/***/ }),
-
-/***/ 747:
-/***/ (function(module) {
-
-module.exports = require("fs");
-
-/***/ }),
-
-/***/ 761:
-/***/ (function(module) {
-
-module.exports = require("zlib");
-
-/***/ }),
-
-/***/ 835:
-/***/ (function(module) {
-
-module.exports = require("url");
 
 /***/ })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -49,12 +49,101 @@ module.exports =
 /************************************************************************/
 /******/ ({
 
-/***/ 0:
+/***/ 87:
+/***/ (function(module) {
+
+module.exports = require("os");
+
+/***/ }),
+
+/***/ 129:
+/***/ (function(module) {
+
+module.exports = require("child_process");
+
+/***/ }),
+
+/***/ 211:
+/***/ (function(module) {
+
+module.exports = require("https");
+
+/***/ }),
+
+/***/ 357:
+/***/ (function(module) {
+
+module.exports = require("assert");
+
+/***/ }),
+
+/***/ 413:
+/***/ (function(module) {
+
+module.exports = require("stream");
+
+/***/ }),
+
+/***/ 429:
 /***/ (function(module, __unusedexports, __webpack_require__) {
+
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete installedModules[moduleId];
+/******/ 		}
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	__webpack_require__.ab = __dirname + "/";
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(429);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 0:
+/***/ (function(module, __unusedexports, __nested_webpack_require_1583__) {
 
 module.exports = withDefaults
 
-const graphql = __webpack_require__(500)
+const graphql = __nested_webpack_require_1583__(500)
 
 function withDefaults (request, newDefaults) {
   const newRequest = request.defaults(newDefaults)
@@ -70,13 +159,13 @@ function withDefaults (request, newDefaults) {
 /***/ }),
 
 /***/ 2:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_2012__) {
 
 "use strict";
 
-const os = __webpack_require__(87);
-const macosRelease = __webpack_require__(964);
-const winRelease = __webpack_require__(49);
+const os = __nested_webpack_require_2012__(87);
+const macosRelease = __nested_webpack_require_2012__(964);
+const winRelease = __nested_webpack_require_2012__(49);
 
 const osName = (platform, release) => {
 	if (!platform && release) {
@@ -158,9 +247,9 @@ function iterator (octokit, options) {
 /***/ }),
 
 /***/ 9:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_4093__) {
 
-var once = __webpack_require__(969);
+var once = __nested_webpack_require_4093__(969);
 
 var noop = function() {};
 
@@ -307,13 +396,13 @@ module.exports = eval("require")("encoding");
 /***/ }),
 
 /***/ 19:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_7919__) {
 
 module.exports = authenticationPlugin
 
-const authenticate = __webpack_require__(674)
-const beforeRequest = __webpack_require__(471)
-const requestError = __webpack_require__(349)
+const authenticate = __nested_webpack_require_7919__(674)
+const beforeRequest = __nested_webpack_require_7919__(471)
+const requestError = __nested_webpack_require_7919__(349)
 
 function authenticationPlugin (octokit, options) {
   if (options.auth) {
@@ -335,14 +424,14 @@ function authenticationPlugin (octokit, options) {
 /***/ }),
 
 /***/ 20:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_8695__) {
 
 "use strict";
 
 
-const cp = __webpack_require__(129);
-const parse = __webpack_require__(568);
-const enoent = __webpack_require__(881);
+const cp = __nested_webpack_require_8695__(129);
+const parse = __nested_webpack_require_8695__(568);
+const enoent = __nested_webpack_require_8695__(881);
 
 function spawn(command, args, options) {
     // Parse the arguments
@@ -404,11 +493,11 @@ module.exports = function generate_comment(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 30:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_10603__) {
 
 module.exports = getLastPage
 
-const getPage = __webpack_require__(265)
+const getPage = __nested_webpack_require_10603__(265)
 
 function getLastPage (octokit, link, headers) {
   return getPage(octokit, link, 'last', headers)
@@ -570,14 +659,14 @@ module.exports = {"_args":[["@octokit/request@2.3.0","/home/eltharim/Dropbox/Art
 /***/ }),
 
 /***/ 45:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_18356__) {
 
 "use strict";
 
 
 var IDENTIFIER = /^[a-z_$][a-z0-9_$-]*$/i;
-var customRuleCode = __webpack_require__(187);
-var definitionSchema = __webpack_require__(952);
+var customRuleCode = __nested_webpack_require_18356__(187);
+var definitionSchema = __nested_webpack_require_18356__(952);
 
 module.exports = {
   add: addKeyword,
@@ -724,11 +813,11 @@ function validateKeyword(definition, throwError) {
 /***/ }),
 
 /***/ 46:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_22349__) {
 
 module.exports = getUserAgentNode
 
-const osName = __webpack_require__(2)
+const osName = __nested_webpack_require_22349__(2)
 
 function getUserAgentNode () {
   try {
@@ -746,12 +835,12 @@ function getUserAgentNode () {
 /***/ }),
 
 /***/ 47:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_22779__) {
 
 module.exports = factory
 
-const Octokit = __webpack_require__(402)
-const registerPlugin = __webpack_require__(855)
+const Octokit = __nested_webpack_require_22779__(402)
+const registerPlugin = __nested_webpack_require_22779__(855)
 
 function factory (plugins) {
   const Api = Octokit.bind(null, plugins || [])
@@ -763,12 +852,12 @@ function factory (plugins) {
 /***/ }),
 
 /***/ 49:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_23131__) {
 
 "use strict";
 
-const os = __webpack_require__(87);
-const execa = __webpack_require__(955);
+const os = __nested_webpack_require_23131__(87);
+const execa = __nested_webpack_require_23131__(955);
 
 // Reference: https://www.gaijin.at/en/lstwinver.php
 const names = new Map([
@@ -913,7 +1002,7 @@ module.exports = function generate__limitItems(it, $keyword, $ruleType) {
 /***/ 87:
 /***/ (function(module) {
 
-module.exports = require("os");
+module.exports = __webpack_require__(87);
 
 /***/ }),
 
@@ -968,13 +1057,13 @@ module.exports = function generate_allOf(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 118:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_29057__) {
 
 module.exports = withDefaults
 
-const endpointWithDefaults = __webpack_require__(284)
-const merge = __webpack_require__(742)
-const parse = __webpack_require__(474)
+const endpointWithDefaults = __nested_webpack_require_29057__(284)
+const merge = __nested_webpack_require_29057__(742)
+const parse = __nested_webpack_require_29057__(474)
 
 function withDefaults (oldDefaults, newDefaults) {
   const DEFAULTS = merge(oldDefaults, newDefaults)
@@ -1895,17 +1984,17 @@ module.exports = uniq;
 /***/ 129:
 /***/ (function(module) {
 
-module.exports = require("child_process");
+module.exports = __webpack_require__(129);
 
 /***/ }),
 
 /***/ 145:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_51628__) {
 
 "use strict";
 
-const pump = __webpack_require__(453);
-const bufferStream = __webpack_require__(966);
+const pump = __nested_webpack_require_51628__(453);
+const bufferStream = __nested_webpack_require_51628__(966);
 
 class MaxBufferError extends Error {
 	constructor() {
@@ -1965,12 +2054,12 @@ module.exports = {"$schema":"http://json-schema.org/draft-07/schema#","type":"ob
 /***/ }),
 
 /***/ 148:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_54929__) {
 
 module.exports = paginatePlugin
 
-const iterator = __webpack_require__(8)
-const paginate = __webpack_require__(807)
+const iterator = __nested_webpack_require_54929__(8)
+const paginate = __nested_webpack_require_54929__(807)
 
 function paginatePlugin (octokit) {
   octokit.paginate = paginate.bind(null, octokit)
@@ -2367,13 +2456,13 @@ module.exports = function generate_custom(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 190:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_69601__) {
 
 module.exports = authenticationPlugin
 
-const beforeRequest = __webpack_require__(863)
-const requestError = __webpack_require__(991)
-const validate = __webpack_require__(954)
+const beforeRequest = __nested_webpack_require_69601__(863)
+const requestError = __nested_webpack_require_69601__(991)
+const validate = __nested_webpack_require_69601__(954)
 
 function authenticationPlugin (octokit, options) {
   if (!options.auth) {
@@ -2395,12 +2484,12 @@ function authenticationPlugin (octokit, options) {
 /***/ }),
 
 /***/ 197:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_70172__) {
 
 module.exports = isexe
 isexe.sync = sync
 
-var fs = __webpack_require__(747)
+var fs = __nested_webpack_require_70172__(747)
 
 function isexe (path, options, cb) {
   fs.stat(path, function (er, stat) {
@@ -2443,10 +2532,10 @@ function checkMode (stat, options) {
 /***/ }),
 
 /***/ 209:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_71181__) {
 
 // expose internally used `fetch` method for testing/mocking only
-module.exports.fetch = __webpack_require__(454).default
+module.exports.fetch = __nested_webpack_require_71181__(454).default
 
 
 /***/ }),
@@ -2454,7 +2543,7 @@ module.exports.fetch = __webpack_require__(454).default
 /***/ 211:
 /***/ (function(module) {
 
-module.exports = require("https");
+module.exports = __webpack_require__(211);
 
 /***/ }),
 
@@ -2642,11 +2731,11 @@ module.exports = function generate_dependencies(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 242:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_83821__) {
 
 module.exports = withDefaults
 
-const request = __webpack_require__(755)
+const request = __nested_webpack_require_83821__(755)
 
 function withDefaults (oldEndpoint, newDefaults) {
   const endpoint = oldEndpoint.defaults(newDefaults)
@@ -2663,11 +2752,11 @@ function withDefaults (oldEndpoint, newDefaults) {
 /***/ }),
 
 /***/ 248:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_84283__) {
 
 module.exports = octokitRegisterEndpoints
 
-const registerEndpoints = __webpack_require__(899)
+const registerEndpoints = __nested_webpack_require_84283__(899)
 
 function octokitRegisterEndpoints (octokit) {
   octokit.registerEndpoints = registerEndpoints.bind(null, octokit)
@@ -2677,16 +2766,16 @@ function octokitRegisterEndpoints (octokit) {
 /***/ }),
 
 /***/ 260:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_84583__) {
 
 // Note: since nyc uses this module to output coverage, any lines
 // that are in the direct sync flow of nyc's outputCoverage are
 // ignored, since we can never get coverage for them.
-var assert = __webpack_require__(357)
-var signals = __webpack_require__(654)
+var assert = __nested_webpack_require_84583__(357)
+var signals = __nested_webpack_require_84583__(654)
 var isWin = /^win/i.test(process.platform)
 
-var EE = __webpack_require__(614)
+var EE = __nested_webpack_require_84583__(614)
 /* istanbul ignore if */
 if (typeof EE !== 'function') {
   EE = EE.EventEmitter
@@ -2876,13 +2965,13 @@ module.exports = class HttpError extends Error {
 /***/ }),
 
 /***/ 262:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(__unusedmodule, exports, __nested_webpack_require_89460__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const fs_1 = __webpack_require__(747);
-const os_1 = __webpack_require__(87);
+const fs_1 = __nested_webpack_require_89460__(747);
+const os_1 = __nested_webpack_require_89460__(87);
 class Context {
     /**
      * Hydrate the context from the environment
@@ -2928,13 +3017,13 @@ exports.Context = Context;
 /***/ }),
 
 /***/ 265:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_91280__) {
 
 module.exports = getPage
 
-const deprecate = __webpack_require__(370)
-const getPageLinks = __webpack_require__(577)
-const HttpError = __webpack_require__(297)
+const deprecate = __nested_webpack_require_91280__(370)
+const getPageLinks = __nested_webpack_require_91280__(577)
+const HttpError = __nested_webpack_require_91280__(297)
 
 function getPage (octokit, link, which, headers) {
   deprecate(`octokit.get${which.charAt(0).toUpperCase() + which.slice(1)}Page() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -3105,10 +3194,10 @@ module.exports = function generate_ref(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 277:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_97193__) {
 
-const Deprecation = __webpack_require__(832)
-const logOnce = __webpack_require__(969)(deprecation => console.warn(deprecation))
+const Deprecation = __nested_webpack_require_97193__(832)
+const logOnce = __nested_webpack_require_97193__(969)(deprecation => console.warn(deprecation))
 
 module.exports = class HttpError extends Error {
   constructor (message, statusCode, headers, request) {
@@ -4825,12 +4914,12 @@ module.exports = function generate_enum(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 284:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_143212__) {
 
 module.exports = endpointWithDefaults
 
-const merge = __webpack_require__(742)
-const parse = __webpack_require__(474)
+const merge = __nested_webpack_require_143212__(742)
+const parse = __nested_webpack_require_143212__(474)
 
 function endpointWithDefaults (defaults, route, options) {
   return parse(merge(defaults, route, options))
@@ -4869,13 +4958,13 @@ function addQueryParameters (url, parameters) {
 /***/ }),
 
 /***/ 294:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_144076__) {
 
 module.exports = parseOptions
 
-const getUserAgent = __webpack_require__(46)
+const getUserAgent = __nested_webpack_require_144076__(46)
 
-const pkg = __webpack_require__(215)
+const pkg = __nested_webpack_require_144076__(215)
 
 function parseOptions (options, log) {
   if (options.headers) {
@@ -4967,11 +5056,11 @@ function omit (object, keysToOmit) {
 /***/ }),
 
 /***/ 307:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_146544__) {
 
-const getUserAgent = __webpack_require__(46)
+const getUserAgent = __nested_webpack_require_146544__(46)
 
-const version = __webpack_require__(724).version
+const version = __nested_webpack_require_146544__(724).version
 const userAgent = `octokit-endpoint.js/${version} ${getUserAgent()}`
 
 module.exports = {
@@ -5027,11 +5116,11 @@ isStream.transform = function (stream) {
 /***/ }),
 
 /***/ 326:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_150734__) {
 
 module.exports = withDefaults
 
-const request = __webpack_require__(354)
+const request = __nested_webpack_require_150734__(354)
 
 function withDefaults (oldEndpoint, newDefaults) {
   const endpoint = oldEndpoint.defaults(newDefaults)
@@ -5048,12 +5137,12 @@ function withDefaults (oldEndpoint, newDefaults) {
 /***/ }),
 
 /***/ 336:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_151196__) {
 
 module.exports = hasLastPage
 
-const deprecate = __webpack_require__(370)
-const getPageLinks = __webpack_require__(577)
+const deprecate = __nested_webpack_require_151196__(370)
+const getPageLinks = __nested_webpack_require_151196__(577)
 
 function hasLastPage (link) {
   deprecate(`octokit.hasLastPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -5682,16 +5771,16 @@ module.exports = function generate_properties(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 348:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_177086__) {
 
 "use strict";
 
 
 module.exports = validate
 
-const set = __webpack_require__(883)
-const get = __webpack_require__(854)
-const HttpError = __webpack_require__(261)
+const set = __nested_webpack_require_177086__(883)
+const get = __nested_webpack_require_177086__(854)
+const HttpError = __nested_webpack_require_177086__(261)
 
 function validate (options) {
   if (!options.request.validate) {
@@ -5791,11 +5880,11 @@ function validate (options) {
 /***/ }),
 
 /***/ 349:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_180523__) {
 
 module.exports = authenticationRequestError
 
-const HttpError = __webpack_require__(261)
+const HttpError = __nested_webpack_require_180523__(261)
 
 function authenticationRequestError (state, error, options) {
   const otpRequired = /required/.test(error.headers['x-github-otp'] || '')
@@ -5828,15 +5917,15 @@ function authenticationRequestError (state, error, options) {
 /***/ }),
 
 /***/ 354:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_181694__) {
 
 module.exports = request
 
-const isPlainObject = __webpack_require__(960)
+const isPlainObject = __nested_webpack_require_181694__(960)
 
-const mockable = __webpack_require__(209)
-const getBuffer = __webpack_require__(972)
-const HttpError = __webpack_require__(261)
+const mockable = __nested_webpack_require_181694__(209)
+const getBuffer = __nested_webpack_require_181694__(972)
+const HttpError = __nested_webpack_require_181694__(261)
 
 function request (requestOptions) {
   if (isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
@@ -5932,7 +6021,7 @@ function request (requestOptions) {
 /***/ 357:
 /***/ (function(module) {
 
-module.exports = require("assert");
+module.exports = __webpack_require__(357);
 
 /***/ }),
 
@@ -6025,48 +6114,48 @@ function octokitDebug (octokit) {
 /***/ }),
 
 /***/ 383:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_186088__) {
 
 "use strict";
 
 
 //all requires must be explicit because browserify won't work with dynamic requires
 module.exports = {
-  '$ref': __webpack_require__(266),
-  allOf: __webpack_require__(107),
-  anyOf: __webpack_require__(902),
-  '$comment': __webpack_require__(28),
-  const: __webpack_require__(662),
-  contains: __webpack_require__(154),
-  dependencies: __webpack_require__(233),
-  'enum': __webpack_require__(281),
-  format: __webpack_require__(687),
-  'if': __webpack_require__(658),
-  items: __webpack_require__(643),
-  maximum: __webpack_require__(341),
-  minimum: __webpack_require__(341),
-  maxItems: __webpack_require__(85),
-  minItems: __webpack_require__(85),
-  maxLength: __webpack_require__(772),
-  minLength: __webpack_require__(772),
-  maxProperties: __webpack_require__(560),
-  minProperties: __webpack_require__(560),
-  multipleOf: __webpack_require__(397),
-  not: __webpack_require__(673),
-  oneOf: __webpack_require__(653),
-  pattern: __webpack_require__(542),
-  properties: __webpack_require__(343),
-  propertyNames: __webpack_require__(566),
-  required: __webpack_require__(858),
-  uniqueItems: __webpack_require__(434),
-  validate: __webpack_require__(967)
+  '$ref': __nested_webpack_require_186088__(266),
+  allOf: __nested_webpack_require_186088__(107),
+  anyOf: __nested_webpack_require_186088__(902),
+  '$comment': __nested_webpack_require_186088__(28),
+  const: __nested_webpack_require_186088__(662),
+  contains: __nested_webpack_require_186088__(154),
+  dependencies: __nested_webpack_require_186088__(233),
+  'enum': __nested_webpack_require_186088__(281),
+  format: __nested_webpack_require_186088__(687),
+  'if': __nested_webpack_require_186088__(658),
+  items: __nested_webpack_require_186088__(643),
+  maximum: __nested_webpack_require_186088__(341),
+  minimum: __nested_webpack_require_186088__(341),
+  maxItems: __nested_webpack_require_186088__(85),
+  minItems: __nested_webpack_require_186088__(85),
+  maxLength: __nested_webpack_require_186088__(772),
+  minLength: __nested_webpack_require_186088__(772),
+  maxProperties: __nested_webpack_require_186088__(560),
+  minProperties: __nested_webpack_require_186088__(560),
+  multipleOf: __nested_webpack_require_186088__(397),
+  not: __nested_webpack_require_186088__(673),
+  oneOf: __nested_webpack_require_186088__(653),
+  pattern: __nested_webpack_require_186088__(542),
+  properties: __nested_webpack_require_186088__(343),
+  propertyNames: __nested_webpack_require_186088__(566),
+  required: __nested_webpack_require_186088__(858),
+  uniqueItems: __nested_webpack_require_186088__(434),
+  validate: __nested_webpack_require_186088__(967)
 };
 
 
 /***/ }),
 
 /***/ 387:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(__unusedmodule, exports, __nested_webpack_require_187356__) {
 
 "use strict";
 
@@ -6095,14 +6184,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const fs = __importStar(__webpack_require__(747));
-const path = __importStar(__webpack_require__(622));
-const core = __importStar(__webpack_require__(470));
-const github = __importStar(__webpack_require__(469));
-const ajv_1 = __importDefault(__webpack_require__(514));
+const fs = __importStar(__nested_webpack_require_187356__(747));
+const path = __importStar(__nested_webpack_require_187356__(622));
+const core = __importStar(__nested_webpack_require_187356__(470));
+const github = __importStar(__nested_webpack_require_187356__(469));
+const ajv_1 = __importDefault(__nested_webpack_require_187356__(514));
 // import colors from 'colors/safe'
-const utility_1 = __webpack_require__(31);
-const generalCheckSchema = __importStar(__webpack_require__(146));
+const utility_1 = __nested_webpack_require_187356__(31);
+const generalCheckSchema = __importStar(__nested_webpack_require_187356__(146));
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function getChecksToReport() {
     const checks = JSON.parse(core.getInput('checks', { required: true }));
@@ -6290,13 +6379,13 @@ exports.run = run;
 /***/ }),
 
 /***/ 389:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_199276__) {
 
 "use strict";
 
 
-const fs = __webpack_require__(747);
-const shebangCommand = __webpack_require__(866);
+const fs = __nested_webpack_require_199276__(747);
+const shebangCommand = __nested_webpack_require_199276__(866);
 
 function readShebang(command) {
     // Read the first 150 bytes from the file
@@ -6418,15 +6507,15 @@ module.exports = function generate_multipleOf(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 402:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_202974__) {
 
 module.exports = Octokit
 
-const endpoint = __webpack_require__(918).endpoint
-const Hook = __webpack_require__(523)
+const endpoint = __nested_webpack_require_202974__(918).endpoint
+const Hook = __nested_webpack_require_202974__(523)
 
-const parseClientOptions = __webpack_require__(294)
-const requestWithDefaults = __webpack_require__(878)
+const parseClientOptions = __nested_webpack_require_202974__(294)
+const requestWithDefaults = __nested_webpack_require_202974__(878)
 
 function Octokit (plugins, options) {
   options = options || {}
@@ -6454,18 +6543,18 @@ function Octokit (plugins, options) {
 /***/ 413:
 /***/ (function(module) {
 
-module.exports = require("stream");
+module.exports = __webpack_require__(413);
 
 /***/ }),
 
 /***/ 417:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_203823__) {
 
 "use strict";
 
 
-var ruleModules = __webpack_require__(383)
-  , toHash = __webpack_require__(949).toHash;
+var ruleModules = __nested_webpack_require_203823__(383)
+  , toHash = __nested_webpack_require_203823__(949).toHash;
 
 module.exports = function rules() {
   var RULES = [
@@ -6533,13 +6622,13 @@ module.exports = function rules() {
 /***/ }),
 
 /***/ 427:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_205946__) {
 
 "use strict";
 
 // Older verions of Node.js might not have `util.getSystemErrorName()`.
 // In that case, fall back to a deprecated internal.
-const util = __webpack_require__(669);
+const util = __nested_webpack_require_205946__(669);
 
 let uv;
 
@@ -6580,12 +6669,12 @@ function errname(uv, code) {
 /***/ }),
 
 /***/ 429:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(__unusedmodule, exports, __nested_webpack_require_206886__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const lib_1 = __webpack_require__(387);
+const lib_1 = __nested_webpack_require_206886__(387);
 process.on("unhandledRejection", (err) => {
     console.error(err, "error");
     throw new Error(`Exiting due to unhandled promise rejection`);
@@ -6596,11 +6685,11 @@ lib_1.run();
 /***/ }),
 
 /***/ 430:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_207254__) {
 
 module.exports = octokitValidate
 
-const validate = __webpack_require__(348)
+const validate = __nested_webpack_require_207254__(348)
 
 function octokitValidate (octokit) {
   octokit.hook.before('request', validate)
@@ -6610,12 +6699,12 @@ function octokitValidate (octokit) {
 /***/ }),
 
 /***/ 431:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(__unusedmodule, exports, __nested_webpack_require_207502__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-const os = __webpack_require__(87);
+const os = __nested_webpack_require_207502__(87);
 /**
  * Commands
  *
@@ -6777,11 +6866,11 @@ module.exports = function generate_uniqueItems(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 453:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_213472__) {
 
-var once = __webpack_require__(969)
-var eos = __webpack_require__(9)
-var fs = __webpack_require__(747) // we only need fs to get the ReadStream and WriteStream prototypes
+var once = __nested_webpack_require_213472__(969)
+var eos = __nested_webpack_require_213472__(9)
+var fs = __nested_webpack_require_213472__(747) // we only need fs to get the ReadStream and WriteStream prototypes
 
 var noop = function () {}
 var ancient = /^v?\.0/.test(process.version)
@@ -6866,7 +6955,7 @@ module.exports = pump
 /***/ }),
 
 /***/ 454:
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __nested_webpack_require_215795__) {
 
 "use strict";
 
@@ -6875,11 +6964,11 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var Stream = _interopDefault(__webpack_require__(413));
-var http = _interopDefault(__webpack_require__(605));
-var Url = _interopDefault(__webpack_require__(835));
-var https = _interopDefault(__webpack_require__(211));
-var zlib = _interopDefault(__webpack_require__(761));
+var Stream = _interopDefault(__nested_webpack_require_215795__(413));
+var http = _interopDefault(__nested_webpack_require_215795__(605));
+var Url = _interopDefault(__nested_webpack_require_215795__(835));
+var https = _interopDefault(__nested_webpack_require_215795__(211));
+var zlib = _interopDefault(__nested_webpack_require_215795__(761));
 
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 
@@ -7030,7 +7119,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = __webpack_require__(18).convert;
+	convert = __nested_webpack_require_215795__(18).convert;
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -8569,7 +8658,7 @@ module.exports.argument = escapeArgument;
 /***/ }),
 
 /***/ 469:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(__unusedmodule, exports, __nested_webpack_require_258484__) {
 
 "use strict";
 
@@ -8585,9 +8674,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 // Originally pulled from https://github.com/JasonEtco/actions-toolkit/blob/master/src/github.ts
-const graphql_1 = __webpack_require__(503);
-const rest_1 = __importDefault(__webpack_require__(613));
-const Context = __importStar(__webpack_require__(262));
+const graphql_1 = __nested_webpack_require_258484__(503);
+const rest_1 = __importDefault(__nested_webpack_require_258484__(613));
+const Context = __importStar(__nested_webpack_require_258484__(262));
 // We need this in order to extend Octokit
 rest_1.default.prototype = new rest_1.default();
 exports.context = new Context.Context();
@@ -8605,7 +8694,7 @@ exports.GitHub = GitHub;
 /***/ }),
 
 /***/ 470:
-/***/ (function(__unusedmodule, exports, __webpack_require__) {
+/***/ (function(__unusedmodule, exports, __nested_webpack_require_259797__) {
 
 "use strict";
 
@@ -8619,9 +8708,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const command_1 = __webpack_require__(431);
-const os = __webpack_require__(87);
-const path = __webpack_require__(622);
+const command_1 = __nested_webpack_require_259797__(431);
+const os = __nested_webpack_require_259797__(87);
+const path = __nested_webpack_require_259797__(622);
 /**
  * The code to exit an action
  */
@@ -8807,12 +8896,12 @@ exports.getState = getState;
 /***/ }),
 
 /***/ 471:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_265799__) {
 
 module.exports = authenticationBeforeRequest
 
-const btoa = __webpack_require__(675)
-const uniq = __webpack_require__(126)
+const btoa = __nested_webpack_require_265799__(675)
+const uniq = __nested_webpack_require_265799__(126)
 
 function authenticationBeforeRequest (state, options) {
   if (!state.auth.type) {
@@ -8854,14 +8943,14 @@ function authenticationBeforeRequest (state, options) {
 /***/ }),
 
 /***/ 474:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_267077__) {
 
 module.exports = toRequestOptions
 
-const urlTemplate = __webpack_require__(714)
-const addQueryParameters = __webpack_require__(293)
-const extractUrlVariableNames = __webpack_require__(838)
-const omit = __webpack_require__(302)
+const urlTemplate = __nested_webpack_require_267077__(714)
+const addQueryParameters = __nested_webpack_require_267077__(293)
+const extractUrlVariableNames = __nested_webpack_require_267077__(838)
+const omit = __nested_webpack_require_267077__(302)
 
 function toRequestOptions (options) {
   // https://fetch.spec.whatwg.org/#methods
@@ -8943,14 +9032,14 @@ function toRequestOptions (options) {
 /***/ }),
 
 /***/ 489:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_270208__) {
 
 "use strict";
 
 
-const path = __webpack_require__(622);
-const which = __webpack_require__(814);
-const pathKey = __webpack_require__(39)();
+const path = __nested_webpack_require_270208__(622);
+const which = __nested_webpack_require_270208__(814);
+const pathKey = __nested_webpack_require_270208__(39)();
 
 function resolveCommandAttempt(parsed, withoutPathExt) {
     const cwd = process.cwd();
@@ -8998,12 +9087,12 @@ module.exports = resolveCommand;
 /***/ }),
 
 /***/ 492:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_271646__) {
 
 "use strict";
 
 
-var util = __webpack_require__(949);
+var util = __nested_webpack_require_271646__(949);
 
 module.exports = SchemaObject;
 
@@ -9015,11 +9104,11 @@ function SchemaObject(obj) {
 /***/ }),
 
 /***/ 500:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_271876__) {
 
 module.exports = graphql
 
-const GraphqlError = __webpack_require__(862)
+const GraphqlError = __nested_webpack_require_271876__(862)
 
 const NON_VARIABLE_OPTIONS = ['method', 'baseUrl', 'url', 'headers', 'request', 'query']
 
@@ -9058,15 +9147,15 @@ function graphql (request, query, options) {
 /***/ }),
 
 /***/ 503:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_272799__) {
 
-const request = __webpack_require__(649)
-const getUserAgent = __webpack_require__(46)
+const request = __nested_webpack_require_272799__(649)
+const getUserAgent = __nested_webpack_require_272799__(46)
 
-const version = __webpack_require__(314).version
+const version = __nested_webpack_require_272799__(314).version
 const userAgent = `octokit-graphql.js/${version} ${getUserAgent()}`
 
-const withDefaults = __webpack_require__(0)
+const withDefaults = __nested_webpack_require_272799__(0)
 
 module.exports = withDefaults(request, {
   method: 'POST',
@@ -9140,20 +9229,20 @@ function addHook (state, kind, name, hook) {
 /***/ }),
 
 /***/ 514:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_277485__) {
 
 "use strict";
 
 
-var compileSchema = __webpack_require__(805)
-  , resolve = __webpack_require__(867)
-  , Cache = __webpack_require__(921)
-  , SchemaObject = __webpack_require__(492)
-  , stableStringify = __webpack_require__(741)
-  , formats = __webpack_require__(635)
-  , rules = __webpack_require__(417)
-  , $dataMetaSchema = __webpack_require__(628)
-  , util = __webpack_require__(949);
+var compileSchema = __nested_webpack_require_277485__(805)
+  , resolve = __nested_webpack_require_277485__(867)
+  , Cache = __nested_webpack_require_277485__(921)
+  , SchemaObject = __nested_webpack_require_277485__(492)
+  , stableStringify = __nested_webpack_require_277485__(741)
+  , formats = __nested_webpack_require_277485__(635)
+  , rules = __nested_webpack_require_277485__(417)
+  , $dataMetaSchema = __nested_webpack_require_277485__(628)
+  , util = __nested_webpack_require_277485__(949);
 
 module.exports = Ajv;
 
@@ -9170,14 +9259,14 @@ Ajv.prototype.errorsText = errorsText;
 Ajv.prototype._addSchema = _addSchema;
 Ajv.prototype._compile = _compile;
 
-Ajv.prototype.compileAsync = __webpack_require__(890);
-var customKeyword = __webpack_require__(45);
+Ajv.prototype.compileAsync = __nested_webpack_require_277485__(890);
+var customKeyword = __nested_webpack_require_277485__(45);
 Ajv.prototype.addKeyword = customKeyword.add;
 Ajv.prototype.getKeyword = customKeyword.get;
 Ajv.prototype.removeKeyword = customKeyword.remove;
 Ajv.prototype.validateKeyword = customKeyword.validate;
 
-var errorClasses = __webpack_require__(844);
+var errorClasses = __nested_webpack_require_277485__(844);
 Ajv.ValidationError = errorClasses.Validation;
 Ajv.MissingRefError = errorClasses.MissingRef;
 Ajv.$dataMetaSchema = $dataMetaSchema;
@@ -9586,11 +9675,11 @@ function addFormat(name, format) {
 function addDefaultMetaSchema(self) {
   var $dataSchema;
   if (self._opts.$data) {
-    $dataSchema = __webpack_require__(339);
+    $dataSchema = __nested_webpack_require_277485__(339);
     self.addMetaSchema($dataSchema, $dataSchema.$id, true);
   }
   if (self._opts.meta === false) return;
-  var metaSchema = __webpack_require__(522);
+  var metaSchema = __nested_webpack_require_277485__(522);
   if (self._opts.$data) metaSchema = $dataMetaSchema(metaSchema, META_SUPPORT_DATA);
   self.addMetaSchema(metaSchema, META_SCHEMA_ID, true);
   self._refs['http://json-schema.org/schema'] = META_SCHEMA_ID;
@@ -9661,11 +9750,11 @@ module.exports = {"$schema":"http://json-schema.org/draft-07/schema#","$id":"htt
 /***/ }),
 
 /***/ 523:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_296208__) {
 
-var register = __webpack_require__(363)
-var addHook = __webpack_require__(510)
-var removeHook = __webpack_require__(763)
+var register = __nested_webpack_require_296208__(363)
+var addHook = __nested_webpack_require_296208__(510)
+var removeHook = __nested_webpack_require_296208__(763)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -9726,9 +9815,9 @@ module.exports.Collection = Hook.Collection
 /***/ }),
 
 /***/ 529:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_298112__) {
 
-const factory = __webpack_require__(47)
+const factory = __nested_webpack_require_298112__(47)
 
 module.exports = factory()
 
@@ -9736,12 +9825,12 @@ module.exports = factory()
 /***/ }),
 
 /***/ 536:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_298269__) {
 
 module.exports = hasFirstPage
 
-const deprecate = __webpack_require__(370)
-const getPageLinks = __webpack_require__(577)
+const deprecate = __nested_webpack_require_298269__(370)
+const getPageLinks = __nested_webpack_require_298269__(577)
 
 function hasFirstPage (link) {
   deprecate(`octokit.hasFirstPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -9835,11 +9924,11 @@ module.exports = function generate_pattern(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 550:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_301328__) {
 
 module.exports = getNextPage
 
-const getPage = __webpack_require__(265)
+const getPage = __nested_webpack_require_301328__(265)
 
 function getNextPage (octokit, link, headers) {
   return getPage(octokit, link, 'next', headers)
@@ -9849,12 +9938,12 @@ function getNextPage (octokit, link, headers) {
 /***/ }),
 
 /***/ 558:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_301588__) {
 
 module.exports = hasPreviousPage
 
-const deprecate = __webpack_require__(370)
-const getPageLinks = __webpack_require__(577)
+const deprecate = __nested_webpack_require_301588__(370)
+const getPageLinks = __nested_webpack_require_301588__(577)
 
 function hasPreviousPage (link) {
   deprecate(`octokit.hasPreviousPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -9953,11 +10042,11 @@ module.exports = function generate__limitProperties(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 563:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_304811__) {
 
 module.exports = getPreviousPage
 
-const getPage = __webpack_require__(265)
+const getPage = __nested_webpack_require_304811__(265)
 
 function getPreviousPage (octokit, link, headers) {
   return getPage(octokit, link, 'prev', headers)
@@ -10056,17 +10145,17 @@ module.exports = function generate_propertyNames(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 568:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_308715__) {
 
 "use strict";
 
 
-const path = __webpack_require__(622);
-const niceTry = __webpack_require__(948);
-const resolveCommand = __webpack_require__(489);
-const escape = __webpack_require__(462);
-const readShebang = __webpack_require__(389);
-const semver = __webpack_require__(280);
+const path = __nested_webpack_require_308715__(622);
+const niceTry = __nested_webpack_require_308715__(948);
+const resolveCommand = __nested_webpack_require_308715__(489);
+const escape = __nested_webpack_require_308715__(462);
+const readShebang = __nested_webpack_require_308715__(389);
+const semver = __nested_webpack_require_308715__(280);
 
 const isWin = process.platform === 'win32';
 const isExecutableRegExp = /\.(?:com|exe)$/i;
@@ -10230,10 +10319,10 @@ function getPageLinks (link) {
 /***/ }),
 
 /***/ 585:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_313959__) {
 
-const withDefaults = __webpack_require__(118)
-const DEFAULTS = __webpack_require__(307)
+const withDefaults = __nested_webpack_require_313959__(118)
+const DEFAULTS = __nested_webpack_require_313959__(307)
 
 module.exports = withDefaults(null, DEFAULTS)
 
@@ -10241,11 +10330,11 @@ module.exports = withDefaults(null, DEFAULTS)
 /***/ }),
 
 /***/ 586:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_314183__) {
 
 module.exports = octokitRestApiEndpoints
 
-const ROUTES = __webpack_require__(705)
+const ROUTES = __nested_webpack_require_314183__(705)
 
 function octokitRestApiEndpoints (octokit) {
   // Aliasing scopes for backward compatibility
@@ -10263,25 +10352,25 @@ function octokitRestApiEndpoints (octokit) {
 /***/ 605:
 /***/ (function(module) {
 
-module.exports = require("http");
+module.exports = __webpack_require__(605);
 
 /***/ }),
 
 /***/ 613:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_314744__) {
 
-const Octokit = __webpack_require__(529)
+const Octokit = __nested_webpack_require_314744__(529)
 
 const CORE_PLUGINS = [
-  __webpack_require__(372),
-  __webpack_require__(19), // deprecated: remove in v17
-  __webpack_require__(190),
-  __webpack_require__(148),
-  __webpack_require__(248),
-  __webpack_require__(586),
-  __webpack_require__(430),
+  __nested_webpack_require_314744__(372),
+  __nested_webpack_require_314744__(19), // deprecated: remove in v17
+  __nested_webpack_require_314744__(190),
+  __nested_webpack_require_314744__(148),
+  __nested_webpack_require_314744__(248),
+  __nested_webpack_require_314744__(586),
+  __nested_webpack_require_314744__(430),
 
-  __webpack_require__(850) // deprecated: remove in v17
+  __nested_webpack_require_314744__(850) // deprecated: remove in v17
 ]
 
 module.exports = Octokit.plugin(CORE_PLUGINS)
@@ -10292,17 +10381,17 @@ module.exports = Octokit.plugin(CORE_PLUGINS)
 /***/ 614:
 /***/ (function(module) {
 
-module.exports = require("events");
+module.exports = __webpack_require__(614);
 
 /***/ }),
 
 /***/ 621:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_315314__) {
 
 "use strict";
 
-const path = __webpack_require__(622);
-const pathKey = __webpack_require__(39);
+const path = __nested_webpack_require_315314__(622);
+const pathKey = __nested_webpack_require_315314__(39);
 
 module.exports = opts => {
 	opts = Object.assign({
@@ -10346,7 +10435,7 @@ module.exports.env = opts => {
 /***/ 622:
 /***/ (function(module) {
 
-module.exports = require("path");
+module.exports = __webpack_require__(622);
 
 /***/ }),
 
@@ -10408,12 +10497,12 @@ module.exports = function (metaSchema, keywordsJsonPointers) {
 /***/ }),
 
 /***/ 635:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_317367__) {
 
 "use strict";
 
 
-var util = __webpack_require__(949);
+var util = __nested_webpack_require_317367__(949);
 
 var DATE = /^(\d\d\d\d)-(\d\d)-(\d\d)$/;
 var DAYS = [0,31,28,31,30,31,30,31,31,30,31,30,31];
@@ -10706,14 +10795,14 @@ module.exports = function generate_items(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 649:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_335748__) {
 
-const endpoint = __webpack_require__(585)
-const getUserAgent = __webpack_require__(46)
+const endpoint = __nested_webpack_require_335748__(585)
+const getUserAgent = __nested_webpack_require_335748__(46)
 
-const version = __webpack_require__(509).version
+const version = __nested_webpack_require_335748__(509).version
 const userAgent = `octokit-request.js/${version} ${getUserAgent()}`
-const withDefaults = __webpack_require__(242)
+const withDefaults = __nested_webpack_require_335748__(242)
 
 module.exports = withDefaults(endpoint, {
   headers: {
@@ -11043,7 +11132,7 @@ module.exports = function generate_const(it, $keyword, $ruleType) {
 /***/ 669:
 /***/ (function(module) {
 
-module.exports = require("util");
+module.exports = __webpack_require__(669);
 
 /***/ }),
 
@@ -11678,14 +11767,14 @@ module.exports = function (data, opts) {
 /***/ }),
 
 /***/ 742:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_496947__) {
 
 module.exports = defaultOptions
 
-const merge = __webpack_require__(278)
-const isPlainObject = __webpack_require__(960)
+const merge = __nested_webpack_require_496947__(278)
+const isPlainObject = __nested_webpack_require_496947__(960)
 
-const lowercaseKeys = __webpack_require__(571)
+const lowercaseKeys = __nested_webpack_require_496947__(571)
 
 function defaultOptions (defaults, route, options) {
   if (typeof route === 'string') {
@@ -11717,20 +11806,20 @@ function defaultOptions (defaults, route, options) {
 /***/ 747:
 /***/ (function(module) {
 
-module.exports = require("fs");
+module.exports = __webpack_require__(747);
 
 /***/ }),
 
 /***/ 755:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_498183__) {
 
 module.exports = request
 
-const isPlainObject = __webpack_require__(960)
-const nodeFetch = __webpack_require__(454).default
+const isPlainObject = __nested_webpack_require_498183__(960)
+const nodeFetch = __nested_webpack_require_498183__(454).default
 
-const getBuffer = __webpack_require__(163)
-const HttpError = __webpack_require__(277)
+const getBuffer = __nested_webpack_require_498183__(163)
+const HttpError = __nested_webpack_require_498183__(277)
 
 function request (requestOptions) {
   if (isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)) {
@@ -11827,7 +11916,7 @@ function request (requestOptions) {
 /***/ 761:
 /***/ (function(module) {
 
-module.exports = require("zlib");
+module.exports = __webpack_require__(761);
 
 /***/ }),
 
@@ -11978,11 +12067,11 @@ module.exports = function generate__limitLength(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 777:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_504452__) {
 
 module.exports = getFirstPage
 
-const getPage = __webpack_require__(265)
+const getPage = __nested_webpack_require_504452__(265)
 
 function getFirstPage (octokit, link, headers) {
   return getPage(octokit, link, 'first', headers)
@@ -12012,24 +12101,24 @@ module.exports = function isObject(val) {
 /***/ }),
 
 /***/ 805:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_505055__) {
 
 "use strict";
 
 
-var resolve = __webpack_require__(867)
-  , util = __webpack_require__(949)
-  , errorClasses = __webpack_require__(844)
-  , stableStringify = __webpack_require__(741);
+var resolve = __nested_webpack_require_505055__(867)
+  , util = __nested_webpack_require_505055__(949)
+  , errorClasses = __nested_webpack_require_505055__(844)
+  , stableStringify = __nested_webpack_require_505055__(741);
 
-var validateGenerator = __webpack_require__(967);
+var validateGenerator = __nested_webpack_require_505055__(967);
 
 /**
  * Functions below are used inside compiled validations function
  */
 
 var ucs2length = util.ucs2length;
-var equal = __webpack_require__(930);
+var equal = __nested_webpack_require_505055__(930);
 
 // this error is thrown by async schemas to return validation errors via exception
 var ValidationError = errorClasses.Validation;
@@ -12407,11 +12496,11 @@ function vars(arr, statement) {
 /***/ }),
 
 /***/ 807:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_515830__) {
 
 module.exports = paginate
 
-const iterator = __webpack_require__(8)
+const iterator = __nested_webpack_require_515830__(8)
 
 function paginate (octokit, route, options, mapFn) {
   if (typeof options === 'function') {
@@ -12448,14 +12537,14 @@ function gather (results, iterator, mapFn) {
 /***/ }),
 
 /***/ 813:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_516701__) {
 
-var fs = __webpack_require__(747)
+var fs = __nested_webpack_require_516701__(747)
 var core
 if (process.platform === 'win32' || global.TESTING_WINDOWS) {
-  core = __webpack_require__(818)
+  core = __nested_webpack_require_516701__(818)
 } else {
-  core = __webpack_require__(197)
+  core = __nested_webpack_require_516701__(197)
 }
 
 module.exports = isexe
@@ -12512,7 +12601,7 @@ function sync (path, options) {
 /***/ }),
 
 /***/ 814:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_517998__) {
 
 module.exports = which
 which.sync = whichSync
@@ -12521,9 +12610,9 @@ var isWindows = process.platform === 'win32' ||
     process.env.OSTYPE === 'cygwin' ||
     process.env.OSTYPE === 'msys'
 
-var path = __webpack_require__(622)
+var path = __nested_webpack_require_517998__(622)
 var COLON = isWindows ? ';' : ':'
-var isexe = __webpack_require__(813)
+var isexe = __nested_webpack_require_517998__(813)
 
 function getNotFoundError (cmd) {
   var er = new Error('not found: ' + cmd)
@@ -12664,12 +12753,12 @@ module.exports = /^#!.*/;
 /***/ }),
 
 /***/ 818:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_521380__) {
 
 module.exports = isexe
 isexe.sync = sync
 
-var fs = __webpack_require__(747)
+var fs = __nested_webpack_require_521380__(747)
 
 function checkPathExt (path, options) {
   var pathext = options.pathExt !== undefined ?
@@ -12737,7 +12826,7 @@ module.exports = module.exports.Deprecation = Deprecation
 /***/ 835:
 /***/ (function(module) {
 
-module.exports = require("url");
+module.exports = __webpack_require__(835);
 
 /***/ }),
 
@@ -12765,12 +12854,12 @@ function removeNonChars (variableName) {
 /***/ }),
 
 /***/ 844:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_523295__) {
 
 "use strict";
 
 
-var resolve = __webpack_require__(867);
+var resolve = __nested_webpack_require_523295__(867);
 
 module.exports = {
   Validation: errorSubclass(ValidationError),
@@ -12807,19 +12896,19 @@ function errorSubclass(Subclass) {
 /***/ }),
 
 /***/ 850:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_524217__) {
 
 module.exports = paginationMethodsPlugin
 
 function paginationMethodsPlugin (octokit) {
-  octokit.getFirstPage = __webpack_require__(777).bind(null, octokit)
-  octokit.getLastPage = __webpack_require__(30).bind(null, octokit)
-  octokit.getNextPage = __webpack_require__(550).bind(null, octokit)
-  octokit.getPreviousPage = __webpack_require__(563).bind(null, octokit)
-  octokit.hasFirstPage = __webpack_require__(536)
-  octokit.hasLastPage = __webpack_require__(336)
-  octokit.hasNextPage = __webpack_require__(929)
-  octokit.hasPreviousPage = __webpack_require__(558)
+  octokit.getFirstPage = __nested_webpack_require_524217__(777).bind(null, octokit)
+  octokit.getLastPage = __nested_webpack_require_524217__(30).bind(null, octokit)
+  octokit.getNextPage = __nested_webpack_require_524217__(550).bind(null, octokit)
+  octokit.getPreviousPage = __nested_webpack_require_524217__(563).bind(null, octokit)
+  octokit.hasFirstPage = __nested_webpack_require_524217__(536)
+  octokit.hasLastPage = __nested_webpack_require_524217__(336)
+  octokit.hasNextPage = __nested_webpack_require_524217__(929)
+  octokit.hasPreviousPage = __nested_webpack_require_524217__(558)
 }
 
 
@@ -15159,11 +15248,11 @@ module.exports = get;
 /***/ }),
 
 /***/ 855:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_603445__) {
 
 module.exports = registerPlugin
 
-const factory = __webpack_require__(47)
+const factory = __nested_webpack_require_603445__(47)
 
 function registerPlugin (plugins, pluginFunction) {
   return factory(plugins.includes(pluginFunction) ? plugins : plugins.concat(pluginFunction))
@@ -15474,11 +15563,11 @@ module.exports = class GraphqlError extends Error {
 /***/ }),
 
 /***/ 863:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_616675__) {
 
 module.exports = authenticationBeforeRequest
 
-const btoa = __webpack_require__(675)
+const btoa = __nested_webpack_require_616675__(675)
 
 function authenticationBeforeRequest (state, options) {
   if (typeof state.auth === 'string') {
@@ -15537,11 +15626,11 @@ function authenticationBeforeRequest (state, options) {
 /***/ }),
 
 /***/ 866:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_618993__) {
 
 "use strict";
 
-var shebangRegex = __webpack_require__(816);
+var shebangRegex = __nested_webpack_require_618993__(816);
 
 module.exports = function (str) {
 	var match = str.match(shebangRegex);
@@ -15564,16 +15653,16 @@ module.exports = function (str) {
 /***/ }),
 
 /***/ 867:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_619429__) {
 
 "use strict";
 
 
-var URI = __webpack_require__(853)
-  , equal = __webpack_require__(930)
-  , util = __webpack_require__(949)
-  , SchemaObject = __webpack_require__(492)
-  , traverse = __webpack_require__(340);
+var URI = __nested_webpack_require_619429__(853)
+  , equal = __nested_webpack_require_619429__(930)
+  , util = __nested_webpack_require_619429__(949)
+  , SchemaObject = __nested_webpack_require_619429__(492)
+  , traverse = __nested_webpack_require_619429__(340);
 
 module.exports = resolve;
 
@@ -15842,11 +15931,11 @@ function resolveIds(schema) {
 /***/ }),
 
 /***/ 878:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_627372__) {
 
 module.exports = withDefaults
 
-const request = __webpack_require__(354)
+const request = __nested_webpack_require_627372__(354)
 
 function withDefaults (hook, oldEndpoint, newDefaults) {
   const endpoint = oldEndpoint.defaults(newDefaults)
@@ -16932,12 +17021,12 @@ module.exports = set;
 /***/ }),
 
 /***/ 890:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_654858__) {
 
 "use strict";
 
 
-var MissingRefError = __webpack_require__(844).MissingRef;
+var MissingRefError = __nested_webpack_require_654858__(844).MissingRef;
 
 module.exports = compileAsync;
 
@@ -17157,14 +17246,14 @@ module.exports = function generate_anyOf(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 918:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_661623__) {
 
-const endpoint = __webpack_require__(585)
-const getUserAgent = __webpack_require__(46)
+const endpoint = __nested_webpack_require_661623__(585)
+const getUserAgent = __nested_webpack_require_661623__(46)
 
-const version = __webpack_require__(41).version
+const version = __nested_webpack_require_661623__(41).version
 const userAgent = `octokit-request.js/${version} ${getUserAgent()}`
-const withDefaults = __webpack_require__(326)
+const withDefaults = __nested_webpack_require_661623__(326)
 
 module.exports = withDefaults(endpoint, {
   headers: {
@@ -17210,12 +17299,12 @@ Cache.prototype.clear = function Cache_clear() {
 /***/ }),
 
 /***/ 929:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_662514__) {
 
 module.exports = hasNextPage
 
-const deprecate = __webpack_require__(370)
-const getPageLinks = __webpack_require__(577)
+const deprecate = __nested_webpack_require_662514__(370)
+const getPageLinks = __nested_webpack_require_662514__(577)
 
 function hasNextPage (link) {
   deprecate(`octokit.hasNextPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -17299,7 +17388,7 @@ module.exports = function(fn) {
 /***/ }),
 
 /***/ 949:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_664516__) {
 
 "use strict";
 
@@ -17313,8 +17402,8 @@ module.exports = {
   toHash: toHash,
   getProperty: getProperty,
   escapeQuotes: escapeQuotes,
-  equal: __webpack_require__(930),
-  ucs2length: __webpack_require__(691),
+  equal: __nested_webpack_require_664516__(930),
+  ucs2length: __nested_webpack_require_664516__(691),
   varOccurences: varOccurences,
   varReplace: varReplace,
   schemaHasRules: schemaHasRules,
@@ -17546,12 +17635,12 @@ function unescapeJsonPointer(str) {
 /***/ }),
 
 /***/ 952:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_671579__) {
 
 "use strict";
 
 
-var metaSchema = __webpack_require__(522);
+var metaSchema = __nested_webpack_require_671579__(522);
 
 module.exports = {
   $id: 'https://github.com/ajv-validator/ajv/blob/master/lib/definition_schema.js',
@@ -17619,21 +17708,21 @@ function validateAuth (auth) {
 /***/ }),
 
 /***/ 955:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_672923__) {
 
 "use strict";
 
-const path = __webpack_require__(622);
-const childProcess = __webpack_require__(129);
-const crossSpawn = __webpack_require__(20);
-const stripEof = __webpack_require__(768);
-const npmRunPath = __webpack_require__(621);
-const isStream = __webpack_require__(323);
-const _getStream = __webpack_require__(145);
-const pFinally = __webpack_require__(697);
-const onExit = __webpack_require__(260);
-const errname = __webpack_require__(427);
-const stdio = __webpack_require__(168);
+const path = __nested_webpack_require_672923__(622);
+const childProcess = __nested_webpack_require_672923__(129);
+const crossSpawn = __nested_webpack_require_672923__(20);
+const stripEof = __nested_webpack_require_672923__(768);
+const npmRunPath = __nested_webpack_require_672923__(621);
+const isStream = __nested_webpack_require_672923__(323);
+const _getStream = __nested_webpack_require_672923__(145);
+const pFinally = __nested_webpack_require_672923__(697);
+const onExit = __nested_webpack_require_672923__(260);
+const errname = __nested_webpack_require_672923__(427);
+const stdio = __nested_webpack_require_672923__(168);
 
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
@@ -17988,7 +18077,7 @@ module.exports.shellSync = (cmd, opts) => handleShell(module.exports.sync, cmd, 
 /***/ }),
 
 /***/ 960:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_680719__) {
 
 "use strict";
 /*!
@@ -18000,7 +18089,7 @@ module.exports.shellSync = (cmd, opts) => handleShell(module.exports.sync, cmd, 
 
 
 
-var isObject = __webpack_require__(782);
+var isObject = __nested_webpack_require_680719__(782);
 
 function isObjectObject(o) {
   return isObject(o) === true
@@ -18033,11 +18122,11 @@ module.exports = function isPlainObject(o) {
 /***/ }),
 
 /***/ 964:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_681670__) {
 
 "use strict";
 
-const os = __webpack_require__(87);
+const os = __nested_webpack_require_681670__(87);
 
 const nameMap = new Map([
 	[20, ['Big Sur', '11']],
@@ -18077,11 +18166,11 @@ module.exports.default = macosRelease;
 /***/ }),
 
 /***/ 966:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_682595__) {
 
 "use strict";
 
-const {PassThrough} = __webpack_require__(413);
+const {PassThrough} = __nested_webpack_require_682595__(413);
 
 module.exports = options => {
 	options = Object.assign({}, options);
@@ -18634,9 +18723,9 @@ module.exports = function generate_validate(it, $keyword, $ruleType) {
 /***/ }),
 
 /***/ 969:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_703827__) {
 
-var wrappy = __webpack_require__(11)
+var wrappy = __nested_webpack_require_703827__(11)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -18695,11 +18784,11 @@ function getBufferResponse (response) {
 /***/ }),
 
 /***/ 991:
-/***/ (function(module, __unusedexports, __webpack_require__) {
+/***/ (function(module, __unusedexports, __nested_webpack_require_705013__) {
 
 module.exports = authenticationRequestError
 
-const HttpError = __webpack_require__(261)
+const HttpError = __nested_webpack_require_705013__(261)
 
 function authenticationRequestError (state, error, options) {
   const otpRequired = /required/.test(error.headers['x-github-otp'] || '')
@@ -18728,6 +18817,59 @@ function authenticationRequestError (state, error, options) {
     })
 }
 
+
+/***/ })
+
+/******/ });
+
+/***/ }),
+
+/***/ 605:
+/***/ (function(module) {
+
+module.exports = require("http");
+
+/***/ }),
+
+/***/ 614:
+/***/ (function(module) {
+
+module.exports = require("events");
+
+/***/ }),
+
+/***/ 622:
+/***/ (function(module) {
+
+module.exports = require("path");
+
+/***/ }),
+
+/***/ 669:
+/***/ (function(module) {
+
+module.exports = require("util");
+
+/***/ }),
+
+/***/ 747:
+/***/ (function(module) {
+
+module.exports = require("fs");
+
+/***/ }),
+
+/***/ 761:
+/***/ (function(module) {
+
+module.exports = require("zlib");
+
+/***/ }),
+
+/***/ 835:
+/***/ (function(module) {
+
+module.exports = require("url");
 
 /***/ })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ci-checks-action",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"description": "Create Github annotated checks from script output files",
 	"main": "dist/index.js",
 	"files": [

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -32,6 +32,7 @@ export function parse(generalCheckJSON: string, changedFiles: string[] | undefin
 	// console.log(`Parsing check JSON: "${generalCheckJSON}"`)
 	// console.log(`changed files: ${changedFiles}`)
 
+	// eslint-disable-next-line init-declarations
 	let toValidate
 	try {
 		toValidate = JSON.parse(generalCheckJSON)

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -32,7 +32,20 @@ export function parse(generalCheckJSON: string, changedFiles: string[] | undefin
 	// console.log(`Parsing check JSON: "${generalCheckJSON}"`)
 	// console.log(`changed files: ${changedFiles}`)
 
-	const toValidate = JSON.parse(generalCheckJSON)
+	let toValidate
+	try {
+		toValidate = JSON.parse(generalCheckJSON)
+	}
+	catch (err) {
+		return {
+			title: "Could not parse the output file",
+			summary: err,
+			conclusion: 'failure' as GitHubAnnotation.Conclusion,
+			text: generalCheckJSON,
+			annotations: []
+		}
+	}
+
 	const valid = new Ajv().validate(generalCheckSchema, toValidate)
 	if (valid === false) {
 		throw new Error(`Error parsing check script output`)

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -83,6 +83,11 @@ describe('parse()', function () {
 		}
 	}`
 
+	const wrongFormatReport = `{
+		"description": "ES Lint results",
+		"counts": [object Object]
+	}`
+
 	const testReport = `{
 		"name": "Mocha unit tests",
 		"description": "Mocha unit tests",
@@ -253,12 +258,12 @@ describe('parse()', function () {
 
 		const annotations = [...parse(lintReport, [], undefined).annotations]
 
-		assert.deepEqual(annotations, [])
+		assert.deepStrictEqual(annotations, [])
 	})
 
 	it('should return all annotations, if changed files is undefined', function () {
 		const annotations = [...parse(lintReport, undefined, "lint").annotations]
-		assert.deepEqual(annotations.map(a => a.path), [
+		assert.deepStrictEqual(annotations.map(a => a.path), [
 			`/Users/prmph/Code/ci-checks-action/src/check-general.schema.json`,
 			`/Users/prmph/Code/ci-checks-action/src/index.ts`,
 			"/Users/prmph/Code/ci-checks-action/src/check-general.test.json"]
@@ -267,26 +272,31 @@ describe('parse()', function () {
 
 	it('should return annotations for changed files only, if changed files is a non-empty array', function () {
 		const annotations = [...parse(lintReport, changedFiles, "lint").annotations]
-		assert.deepEqual(annotations.map(a => a.path), [`/Users/prmph/Code/ci-checks-action/src/index.ts`])
+		assert.deepStrictEqual(annotations.map(a => a.path), [`/Users/prmph/Code/ci-checks-action/src/index.ts`])
 	})
 
 	it('should not repeat annotations', function () {
 		const annotations = [...parse(testReport, changedFiles, "lint").annotations]
-		assert.deepEqual(annotations.length, new Set(annotations).size)
+		assert.deepStrictEqual(annotations.length, new Set(annotations).size)
 	})
 
 	it('should include endColumn and startColumn in the annotation when the startLine and endLine are the same', function () {
 		const annotations = [...parse(lintReport, ["/Users/prmph/Code/ci-checks-action/src/index.ts"], "lint").annotations]
-		
-		assert.equal(Object.keys(annotations[0]).includes("start_column"), true)
-		assert.equal(Object.keys(annotations[0]).includes("end_column"), true)
+
+		assert.strictEqual(Object.keys(annotations[0]).includes("start_column"), true)
+		assert.strictEqual(Object.keys(annotations[0]).includes("end_column"), true)
 	})
 
 	it('should omit endColumn and startColumn in the annotation when the startLine and endLine are different', function () {
 		const annotations = [...parse(lintReport, ["/Users/prmph/Code/ci-checks-action/src/check-general.test.json"], "lint").annotations]
 
-		assert.equal(Object.keys(annotations[0]).includes("start_column"), false)
-		assert.equal(Object.keys(annotations[0]).includes("end_column"), false)
+		assert.strictEqual(Object.keys(annotations[0]).includes("start_column"), false)
+		assert.strictEqual(Object.keys(annotations[0]).includes("end_column"), false)
+	})
+
+	it('should return information about a wrongly formatted file instead of throwing an error', function () {
+		const report = parse(wrongFormatReport, [], "lint")
+
+		assert.strictEqual(report.title, "Could not parse the output file")
 	})
 })
-


### PR DESCRIPTION
Resolves #20 

**Merge message:**
- Put the parsing of the output file inside a try-catch block, to return information about the file in case of parsing error.
- Added a unit test to ensure that a parsing failure returns a readable error